### PR TITLE
CSCOIVA-548: Poista linkki järjestäjän näkymästä

### DIFF
--- a/src/routes/Jarjestajat/Jarjestaja/components/Jarjestamislupa.js
+++ b/src/routes/Jarjestajat/Jarjestaja/components/Jarjestamislupa.js
@@ -43,7 +43,6 @@ class Jarjestamislupa extends Component {
     const { ytunnus } = this.props
     const { esittelija } = meta
     const url = muutospyynnot.data.length > 0 ? `/jarjestajat/${ytunnus}/hakemukset-ja-paatokset` : `/jarjestajat/${ytunnus}/hakemukset-ja-paatokset/uusi`
-    const linkText = muutospyynnot.data.length > 0 ? 'Katso muutosta' : 'Hae muutosta'
 
     return (
       <InnerContentContainer>
@@ -58,12 +57,8 @@ class Jarjestamislupa extends Component {
           <LupaDetailsWrapper>
             {Object.keys(LUPA_SECTIONS).map((k, i) =>
               <LupaSection
-                renderMuutosLink={true}
                 kohde={kohteet[k]}
-                diaarinumero={diaarinumero}
                 ytunnus={jarjestajaYtunnus}
-                url={url}
-                linkText={linkText}
                 key={i}
               />
             )}

--- a/src/routes/Jarjestajat/Jarjestaja/components/LupaSection.js
+++ b/src/routes/Jarjestajat/Jarjestaja/components/LupaSection.js
@@ -45,12 +45,6 @@ const H3 = styled.h3`
   font-size: 20px;
 `
 
-const MuutosLink = styled(Link)`
-  position: absolute;
-  right: 15px;
-  top: 6px;
-`
-
 const Capitalized = styled.p`
   text-transform: capitalize;
   margin-left: 30px;
@@ -89,7 +83,7 @@ class LupaSection extends Component {
 
 
   render() {
-    const { kohde, diaarinumero, ytunnus, renderMuutosLink, url, linkText } = this.props
+    const { kohde, diaarinumero, ytunnus } = this.props
 
     // const { isRemoving } = this.state
 
@@ -111,10 +105,6 @@ class LupaSection extends Component {
 
               <Kohde1>{`${headingNumber}.`}</Kohde1>
               <H3>{heading}</H3>
-              {url
-                ? <MuutosLink to={url} diaarinumero={diaarinumero} kohdeid={headingNumber}>{linkText}</MuutosLink>
-                : null
-              }
               <div>
                 <Tutkinnot>
                   {_.map(maaraykset, (ala, i) => <Koulutusala key={i} {...ala} />)}


### PR DESCRIPTION
Kirjautuneena koulutuksen järjestäjänä järjestämislupa-välilehdellä ei enää näytetä hae muutosta/katso muutosta -linkkiä.