### PR TITLE
CSCOIVA-570: Tutkintokielilistan korjauksia

### DIFF
--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -31,7 +31,7 @@ class MuutospyyntoWizardMuutokset extends Component {
     const {
       onSubmit,
       save,
-      update,
+//      update,
       lupa,
       fetchKoulutusalat,
       fetchKoulutuksetAll,

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -12,6 +12,7 @@ import { Button, SubtleButton, Kohde, WizardBottom, Container } from "./Muutospy
 import styled from 'styled-components'
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import { hasFormChanges } from "../modules/muutospyyntoUtil"
+import { MUUT_KEYS } from "../modules/constants"
 
 const Otsikko = styled.div`
   display: flex;
@@ -27,16 +28,29 @@ class MuutospyyntoWizardMuutokset extends Component {
     }
   }
 
+  componentWillMount() {
+    // MuutospyyntoWIzardTutkinnot ja MuutospyyntoWizardTutkintokielet tarvitsevat listan tutkinnoista
+    if (!this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
+      this.props.fetchKoulutusalat()
+        .then(() => {
+          if (this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
+            this.props.fetchKoulutuksetAll()
+            this.props.fetchKoulutuksetMuut(MUUT_KEYS.KULJETTAJAKOULUTUS)
+            this.props.fetchKoulutuksetMuut(MUUT_KEYS.OIVA_TYOVOIMAKOULUTUS)
+            this.props.fetchKoulutuksetMuut(MUUT_KEYS.AMMATILLISEEN_TEHTAVAAN_VALMISTAVA_KOULUTUS)
+            this.props.fetchKoulutus("999901")
+            this.props.fetchKoulutus("999903")
+          }
+        })
+    }
+  }
+
   render() {
     const {
       onSubmit,
       save,
 //      update,
       lupa,
-      fetchKoulutusalat,
-      fetchKoulutuksetAll,
-      fetchKoulutuksetMuut,
-      fetchKoulutus,
       formValues
     } = this.props
 
@@ -51,10 +65,6 @@ class MuutospyyntoWizardMuutokset extends Component {
         <form onSubmit={onSubmit}>
           <MuutospyyntoWizardTutkinnot
             lupa={lupa}
-            fetchKoulutusalat={fetchKoulutusalat}
-            fetchKoulutuksetAll={fetchKoulutuksetAll}
-            fetchKoulutuksetMuut={fetchKoulutuksetMuut}
-            fetchKoulutus={fetchKoulutus}
           />
 
           <Kohde>
@@ -64,10 +74,6 @@ class MuutospyyntoWizardMuutokset extends Component {
 
             <MuutospyyntoWizardTutkintokieletContainer
               lupa={lupa}
-              fetchKoulutusalat={fetchKoulutusalat}
-              fetchKoulutuksetAll={fetchKoulutuksetAll}
-              fetchKoulutuksetMuut={fetchKoulutuksetMuut}
-              fetchKoulutus={fetchKoulutus}
             />
           </Kohde>
 
@@ -123,6 +129,7 @@ export default connect(state => {
   }
 
   return {
-    formValues: formVals
+    formValues: formVals,
+    koulutusalat: state.koulutusalat
   }
 })(MuutospyyntoWizardMuutokset)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -64,6 +64,10 @@ class MuutospyyntoWizardMuutokset extends Component {
 
             <MuutospyyntoWizardTutkintokieletContainer
               lupa={lupa}
+              fetchKoulutusalat={fetchKoulutusalat}
+              fetchKoulutuksetAll={fetchKoulutuksetAll}
+              fetchKoulutuksetMuut={fetchKoulutuksetMuut}
+              fetchKoulutus={fetchKoulutus}
             />
           </Kohde>
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
@@ -162,7 +162,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
           <KoulutusList
             key="ammatilliseentehtavaanvalmistavakoulutus"
             koodisto="ammatilliseentehtavaanvalmistavakoulutus"
-            nimi="Ammatilliseen tehtavaan valmistavat koulutukset"
+            nimi="Ammatilliseen tehtävään valmistavat koulutukset"
             koulutukset={muut.ammatilliseentehtavaanvalmistavakoulutus}
             muutMaaraykset={muutMaaraykset}
             editValues={editValue}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Field, FieldArray, reduxForm, formValueSelector } from 'redux-form'
+import { FieldArray, reduxForm, formValueSelector } from 'redux-form'
 import validate from '../modules/validateWizard'
 import { TUTKINTO_TEKSTIT } from "../../../modules/constants"
 import TutkintoList from './TutkintoList'
@@ -16,13 +16,9 @@ import {
   Kohde,
   Info,
 } from './MuutospyyntoWizardComponents'
-import { FIELD_ARRAY_NAMES, FORM_NAME_UUSI_HAKEMUS, MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
+import { FIELD_ARRAY_NAMES, FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 
 class MuutospyyntoWizardTutkinnot extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   render() {
     const { lupa, tutkintomuutoksetValue } = this.props
     const { kohteet } = lupa
@@ -73,8 +69,6 @@ class MuutospyyntoWizardTutkinnot extends Component {
               <FieldArray
                 name={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
                 kohde={kohteet[1]}
-                lupa={lupa}
-                muut={muuData}
                 poikkeukset={poikkeusData}
                 editValue={tutkintomuutoksetValue}
                 component={this.renderKoulutukset}
@@ -94,8 +88,8 @@ class MuutospyyntoWizardTutkinnot extends Component {
 
   renderTutkinnot(props) {
     let { fields, data } = props
-    const { kohde, lupa, editValue, muut } = props
-    const { headingNumber, heading, maaraykset, muutMaaraykset } = kohde
+    const { kohde, editValue } = props
+    const { maaraykset } = kohde
 
     data = _.sortBy(data, d => {
       return d.koodiArvo

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Field, FieldArray, reduxForm, formValueSelector } from 'redux-form'
 import validate from '../modules/validateWizard'
-import { MUUT_KEYS } from "../modules/constants"
 import { TUTKINTO_TEKSTIT } from "../../../modules/constants"
 import TutkintoList from './TutkintoList'
 import KoulutusList from './KoulutusList'
@@ -22,22 +21,6 @@ import { FIELD_ARRAY_NAMES, FORM_NAME_UUSI_HAKEMUS, MUUTOS_TYPES } from "../modu
 class MuutospyyntoWizardTutkinnot extends Component {
   constructor(props) {
     super(props)
-  }
-
-  componentWillMount() {
-    if (!this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
-      this.props.fetchKoulutusalat()
-        .then(() => {
-          if (this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
-            this.props.fetchKoulutuksetAll()
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.KULJETTAJAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.OIVA_TYOVOIMAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.AMMATILLISEEN_TEHTAVAAN_VALMISTAVA_KOULUTUS)
-            this.props.fetchKoulutus("999901")
-            this.props.fetchKoulutus("999903")
-          }
-        })
-    }
   }
 
   render() {
@@ -206,7 +189,6 @@ MuutospyyntoWizardTutkinnot = connect(state => {
 
   return {
     tutkintomuutoksetValue,
-    koulutusalat: state.koulutusalat,
     koulutukset: state.koulutukset,
     paatoskierrokset: state.paatoskierrokset
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
@@ -57,9 +57,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
               <FieldArray
                 name={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
                 kohde={kohteet[1]}
-                lupa={lupa}
                 data={koulutusdata}
-                muut={muuData}
                 editValue={tutkintomuutoksetValue}
                 component={this.renderTutkinnot}
               />
@@ -70,6 +68,8 @@ class MuutospyyntoWizardTutkinnot extends Component {
                 name={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
                 kohde={kohteet[1]}
                 poikkeukset={poikkeusData}
+                lupa={lupa}
+                muut={muuData}
                 editValue={tutkintomuutoksetValue}
                 component={this.renderKoulutukset}
               />

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
@@ -8,7 +8,7 @@ import TutkintoKieliList from './TutkintoKieliList'
 import { ContentContainer} from "../../../../../../modules/elements"
 import { Row } from "./MuutospyyntoWizardComponents"
 import Loading from "../../../../../../modules/Loading"
-import { MUUTOS_WIZARD_TEKSTIT, MUUT_KEYS } from "../modules/constants"
+import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 import { FIELD_ARRAY_NAMES, FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 
@@ -19,21 +19,6 @@ class MuutospyyntoWizardTutkintokielet extends Component {
     if (kielet && !kielet.fetched) {
       this.props.fetchKielet()
     }
-
-    if (!this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
-      this.props.fetchKoulutusalat()
-        .then(() => {
-          if (this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
-            this.props.fetchKoulutuksetAll()
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.KULJETTAJAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.OIVA_TYOVOIMAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.AMMATILLISEEN_TEHTAVAAN_VALMISTAVA_KOULUTUS)
-            this.props.fetchKoulutus("999901")
-            this.props.fetchKoulutus("999903")
-          }
-        })
-    }
-
   }
 
   render() {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
@@ -19,13 +19,14 @@ class MuutospyyntoWizardTutkintokielet extends Component {
     if (kielet && !kielet.fetched) {
       this.props.fetchKielet()
     }
+
   }
 
   render() {
     const { lupa, koulutukset } = this.props
     const { kohteet} = lupa
     const kohde = kohteet[2]
-    const { kielet, tutkintokielimuutoksetValue } = this.props
+    const { kielet, tutkintokielimuutoksetValue, tutkinnotJaKoulutuksetValue } = this.props
 
     if (kielet.fetched) {
       return (
@@ -39,6 +40,7 @@ class MuutospyyntoWizardTutkintokielet extends Component {
               koulutukset={koulutukset}
               kieliList={kielet.kieliList}
               tutkintomaaraykset={kohteet[1].maaraykset}
+              tutkinnotJaKoulutuksetValue={tutkinnotJaKoulutuksetValue}
               editValues={tutkintokielimuutoksetValue}
               component={this.renderTutkintokieliList}
             />
@@ -55,7 +57,7 @@ class MuutospyyntoWizardTutkintokielet extends Component {
   }
 
   renderTutkintokieliList(props) {
-    const { kielet, kieliList, fields, editValues, kohde, tutkintomaaraykset, koulutukset } = props
+    const { kielet, kieliList, fields, editValues, kohde, tutkintomaaraykset, koulutukset, tutkinnotJaKoulutuksetValue } = props
     const { tutkinnotjakielet } = kohde
 
     // TODO: Tarvitaanko valittujen tutkintokielten listausta tässä?
@@ -90,9 +92,11 @@ class MuutospyyntoWizardTutkintokielet extends Component {
                 kielet={kielet}
                 kieliList={kieliList}
                 tutkinnotjakielet={tutkinnotjakielet}
+                tutkinnotJaKoulutuksetValue={tutkinnotJaKoulutuksetValue}
               />
             )
           })}
+
         </Row>
       </div>
     )
@@ -103,9 +107,11 @@ const selector = formValueSelector(FORM_NAME_UUSI_HAKEMUS)
 
 MuutospyyntoWizardTutkintokielet = connect(state => {
   const tutkintokielimuutoksetValue = selector(state, FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET)
+  const tutkinnotJaKoulutuksetValue = selector(state, FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET)
 
   return {
-    tutkintokielimuutoksetValue
+    tutkintokielimuutoksetValue,
+    tutkinnotJaKoulutuksetValue
   }
 })(MuutospyyntoWizardTutkintokielet)
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkintokielet.js
@@ -71,7 +71,7 @@ class MuutospyyntoWizardTutkintokielet extends Component {
 
   renderTutkintokieliList(props) {
     const { kielet, kieliList, fields, editValues, kohde, tutkintomaaraykset, koulutukset } = props
-    const { kohdeArvot, tutkinnotjakielet } = kohde
+    const { tutkinnotjakielet } = kohde
 
     // TODO: Tarvitaanko valittujen tutkintokielten listausta tässä?
     // const valitutKielet = getSelectedTutkintoKielet(tutkinnotjakielet, editValues)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
@@ -62,7 +62,7 @@ class TutkintoKieliList extends Component {
   }
 
   render() {
-    const { nimi, koulutukset, editValues, kielet, kieliList, tutkinnotjakielet } = this.props
+    const { nimi, koulutukset, editValues, kieliList, tutkinnotjakielet } = this.props
     const alaKoodiArvo = this.props.koodiarvo
     let { fields, maaraykset } = this.props
     let muutokset = []
@@ -96,12 +96,6 @@ class TutkintoKieliList extends Component {
       })
     }
 
-    const current = _.find(maaraykset, ala => { return ala.koodi === alaKoodiArvo })
-    let alat = undefined
-    if (current) {
-      alat = current.koulutusalat
-    }
-
     return (
       <Wrapper>
         <Heading onClick={this.toggleTutkintoList.bind(this)}>
@@ -116,7 +110,7 @@ class TutkintoKieliList extends Component {
         {!this.state.isHidden &&
         <KoulutusalaListWrapper>
           {_.map(maaraykset, (tutkinto, i) => {
-            const { koodi, nimi, maaraysId } = tutkinto
+            const { koodi, nimi } = tutkinto
             const identifier = `input-tutkintokieli-2-${koodi}`
 
             const koodiarvo = koodi
@@ -140,19 +134,28 @@ class TutkintoKieliList extends Component {
             if (editValues) {
               editValues.forEach(val => {
                 if (val.koodiarvo === koodi) {
-                  if (val.type === MUUTOS_TYPES.ADDITION) {
-                    valueKoodi = val.value
-                  }
+                  switch(val.type) {
+                    case MUUTOS_TYPES.ADDITION:
+                      valueKoodi = val.value
+                      isAdded = true
+                      break
 
-                  val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : val.type === MUUTOS_TYPES.CHANGE ? isChanged = true : null
+                    case MUUTOS_TYPES.REMOVAL:
+                      isRemoved = true
+                      break
+
+                    case MUUTOS_TYPES.CHANGE:
+                      isChanged = true
+                      break
+
+                    default:
+                      break
+                  }
                 }
               })
             }
 
-            isInLupa ? customClassName = "is-in-lupa" : null
-            isAdded ? customClassName = "is-added" : null
-            isRemoved ? customClassName = "is-removed" : null
-            isChanged ? customClassName = "is-changed" : null
+            customClassName = isInLupa ? "is-in-lupa" : isAdded ? "is-added" : isRemoved ? "is-removed" : isChanged ? "is-changed" : null
 
             if ((isInLupa && !isRemoved)) {
               isChecked = true

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
@@ -67,7 +67,6 @@ class TutkintoKieliList extends Component {
     let { fields, maaraykset } = this.props
     let muutokset = []
 
-
     // Sort languages: promote some common languages, sort others alphabetically
     const kieliListOrdered = kieliList.sort((a, b) => {
       if (a.koodiArvo === 'FI') return -1;
@@ -87,10 +86,9 @@ class TutkintoKieliList extends Component {
       return m.koodi
     })
 
-
     if (editValues) {
       _.forEach(editValues, value => {
-        _.forEach(koulutukset, koulutus => {
+        _.forEach(maaraykset, koulutus => {
           if (koulutus.koodiArvo === value.koodiarvo) {
             muutokset.push(value)
           }
@@ -103,7 +101,6 @@ class TutkintoKieliList extends Component {
     if (current) {
       alat = current.koulutusalat
     }
-
 
     return (
       <Wrapper>
@@ -170,6 +167,9 @@ class TutkintoKieliList extends Component {
             if (isInLupa && isRemoved) {
               value = ''
             }
+
+            // Koulutuksen on oltava voimassa
+            if (!_.find(koulutukset, (k) => { return k.koodiArvo === koodi })) {return false}
 
             return (
               <TutkintoWrapper key={i} className={customClassName}>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
@@ -111,12 +111,6 @@ class TutkintoKieliList extends Component {
         <KoulutusalaListWrapper>
           {_.map(koulutukset, (koulutus, i) => {
 
-            // Tässä kohtaa määräyksistä ja koulutuksista on mukana vain 
-            // tähän alaan liittyvät, muutoksista ihan kaikki.
-            // console.log(koulutus) // objekti: koodiArvo: 123, metadata: [{kieli: 'FI', nimi: 'tutkinnon nimi'}]
-            // console.log(maaraykset) // array: koodi: 123, nimi: "koulutus"
-            // console.log(tutkinnotJaKoulutuksetValue) // array: koodiarvo: 123, nimi: "koulutus"
-
             const identifier = `input-tutkintokieli-2-${koulutus.koodiArvo}`
             const nimiObjekti = _.filter(koulutus.metadata, (m) => { return m.kieli === "FI" })
             const koulutuksenNimi = nimiObjekti[0].nimi

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardTutkintokieletContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardTutkintokieletContainer.js
@@ -7,7 +7,6 @@ import MuutospyyntoWizardTutkintokielet from '../components/MuutospyyntoWizardTu
 const mapStateToProps = (state) => {
   return {
     kielet: state.kielet,
-    koulutusalat: state.koulutusalat,
     koulutukset: state.koulutukset
   }
 }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardTutkintokieletContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardTutkintokieletContainer.js
@@ -6,7 +6,9 @@ import MuutospyyntoWizardTutkintokielet from '../components/MuutospyyntoWizardTu
 
 const mapStateToProps = (state) => {
   return {
-    kielet: state.kielet
+    kielet: state.kielet,
+    koulutusalat: state.koulutusalat,
+    koulutukset: state.koulutukset
   }
 }
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -269,8 +269,13 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
 }
 
 export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isInLupa, value, currentObj) {
-  const { koodi, nimi, maaraysId, kohde, maaraystyyppi } = currentObj
+  const { nimi, kohde, maaraystyyppi } = currentObj
+  let { koodi } = currentObj
   const koodistoUri = "kieli"
+
+  if (!koodi && currentObj.koodiarvo) {
+    koodi = currentObj.koodiarvo
+  }
 
   const { checked } = event.target
 
@@ -287,7 +292,6 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
         koodiarvo: koodi,
         koodisto: koodistoUri,
         nimi,
-        // maaraysId,
         kohde,
         maaraystyyppi,
         value,
@@ -306,7 +310,6 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
         koodi,
         koodisto: koodistoUri,
         nimi,
-        // maaraysId,
         value,
         kohde,
         maaraystyyppi,


### PR DESCRIPTION
Hakemuksen kohta 2 näytti aiemmin kaikki luvasta löytyvät tutkinnot ja koulutukset. Kohtaa muutettiin niin, että kohdassa näytetään

- luvasta löytyvät sekä 
- kohdassa yksi lupaan lisätyt tutkinnot ja koulutukset,

mutta ei kuitenkaan

- kohdassa yksi luvasta poistettuja tutkintoja ja koulutuksia eikä
- käytöstä jo poistuneita tutkintoja ja koulutuksia. (Jos sitä ei ole mahdollista hakea lupaan lisättäväksi, sille ei pitäisi pystyä valitsemaan myöskään tutkintokieltä.)

Mahdollisten koulutusten ja tutkintojen lista haetaan nyt kohdissa yksi ja kaksi yhteisellä koodilla, joka siirtyi MuutospyyntoWizardTutkinnot-komponentista askeleen ylemmäs MuutospyyntoWizardMuutokset-komponenttiin.