### PR TITLE
CSCOIVA-583: Oppisopimuskoulutuksen perustelut yhteenvetoon

### DIFF
--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 
 import PerusteluSimple from './PerusteluSimple'
+import PerusteluOppisopimusYhteenveto from './PerusteluOppisopimusYhteenveto'
 import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
@@ -89,15 +90,27 @@ class MuutosYhteenveto extends Component {
             <Indikaattori status="ok" text="Perusteltu" />
           }
         </MuutosTop>
-        <PerusteluSimple
-          helpText={helpText}
-          koodiarvo={koodiarvo}
-          perusteluteksti={perusteluteksti}
-          muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-          muutokset={muutokset}
-          muutos={muutos}
-          fields={fields}
-        />
+        { koodiarvo === "1" ? 
+          <PerusteluOppisopimusYhteenveto 
+            helpText={helpText}
+            koodiarvo={koodiarvo}
+            perustelut={meta.perusteluteksti_oppisopimus}
+            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+            muutokset={muutokset}
+            muutos={muutos}
+            fields={fields}
+          />
+         :
+          <PerusteluSimple
+            helpText={helpText}
+            koodiarvo={koodiarvo}
+            perusteluteksti={perusteluteksti}
+            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+            muutokset={muutokset}
+            muutos={muutos}
+            fields={fields}
+          />
+          }
       </MuutosWrapper>
     )
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -7,6 +7,7 @@ import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_TYPES, MUUTOS_TYPE_TEXTS } from "../modules/uusiHakemusFormConstants"
+import { KOODISTOT } from "../../../modules/constants"
 
 const MuutosWrapper = styled.div`
   width: 100%;
@@ -90,7 +91,7 @@ class MuutosYhteenveto extends Component {
             <Indikaattori status="ok" text="Perusteltu" />
           }
         </MuutosTop>
-        { koodiarvo === "1" ? 
+        { koodisto === KOODISTOT.OIVA_MUUT && koodiarvo === "1" && type === MUUTOS_TYPES.ADDITION ? 
           <PerusteluOppisopimusYhteenveto 
             helpText={helpText}
             koodiarvo={koodiarvo}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -6,7 +6,6 @@ import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_TYPES, MUUTOS_TYPE_TEXTS } from "../modules/uusiHakemusFormConstants"
-import { getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
 
 const MuutosWrapper = styled.div`
   width: 100%;
@@ -47,8 +46,7 @@ const MuutosTyyppi = styled.div`
 class MuutosYhteenveto extends Component {
   render() {
     const { muutokset, muutos, fields, kategoria } = this.props
-    const { koodiarvo, type, meta, muutosperustelukoodiarvo, koodisto, kuvaus, nimi, label, arvo } = muutos
-    //const nimi = getTutkintoNimiByKoodiarvo(koodiarvo)
+    const { koodiarvo, type, meta, muutosperustelukoodiarvo, koodisto, nimi, label, arvo } = muutos
 
     const { perusteluteksti } = meta
     const helpText = "Perustele lyhyesti miksi tälle muutokselle on tarvetta"

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
@@ -70,8 +70,7 @@ class Perustelu extends Component {
     // koodisto on oiva muut
 
     // laajennettu oppisopimus
-//    if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
-// DEBUG: näytä aina
+   if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
       return (
         <PerusteluWrapper>
           <PerusteluOppisopimus
@@ -83,7 +82,7 @@ class Perustelu extends Component {
           />
         </PerusteluWrapper>
       )
-//    }
+   }
 
     // vaativa erityinen tuki
     // pitääkö tulla vain yksi perustelu-lomake, vaikka kaikki kolme eri vaihtoehtoa on valittu?

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
@@ -70,7 +70,8 @@ class Perustelu extends Component {
     // koodisto on oiva muut
 
     // laajennettu oppisopimus
-    if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
+//    if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
+// DEBUG: näytä aina
       return (
         <PerusteluWrapper>
           <PerusteluOppisopimus
@@ -82,7 +83,7 @@ class Perustelu extends Component {
           />
         </PerusteluWrapper>
       )
-    }
+//    }
 
     // vaativa erityinen tuki
     // pitääkö tulla vain yksi perustelu-lomake, vaikka kaikki kolme eri vaihtoehtoa on valittu?

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimus.js
@@ -116,7 +116,7 @@ class PerusteluOppisopimus extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_2.vuosi = vuosi
+                obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_2.vuosi = parseFloat(vuosi) + 1
                 obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_2.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
@@ -129,7 +129,7 @@ class PerusteluOppisopimus extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_3.vuosi = vuosi
+                obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_3.vuosi = parseFloat(vuosi) + 2
                 obj.meta.perusteluteksti_oppisopimus.vuodet.arvo_3.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+import { COLORS } from "../../../../../../modules/styles"
+import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+
+import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
+
+const PerusteluWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-left: 3px solid ${COLORS.BORDER_GRAY};
+  padding: 0 110px 0 30px;
+  margin: 10px 40px 20px 40px;
+`
+
+const PerusteluInner = styled.div`
+  background-color: ${COLORS.BG_GRAY};
+  padding: 10px 30px;
+`
+
+const Label = styled.div`
+  margin-bottom: 5px;
+`
+
+const Content = styled.div`
+  margin-left: 20px;
+  font-style: italic;
+`
+
+const Area = styled.div`
+  margin: 15px 0;
+`
+
+class PerusteluSimple extends Component {
+  componentWillMount() {
+    const { muutosperustelut } = this.props
+
+    if (muutosperustelut && !muutosperustelut.fetched) {
+      this.props.fetchMuutosperustelut()
+    }
+  }
+
+  render() {
+    const { perustelut, muutosperustelukoodiarvo } = this.props
+    let perusteluText = 'Ei saatavilla'
+    const perusteluObj = getMuutosperusteluByKoodiArvo(muutosperustelukoodiarvo)
+    if (perusteluObj) {
+      perusteluText = perusteluObj.label
+    }
+
+    return (
+      <PerusteluWrapper>
+        <PerusteluInner>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.TARPEELLISUUS.FI}</Label>
+            <Content>{perustelut.tarpeellisuus || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.OPPISOPIMUS.JARJESTAMISEDELLYTYKSET.FI}</Label>
+            <Content>{perustelut.henkilosto || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OSAAMINEN.FI}</Label>
+            <Content>{perustelut.osaaminen || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.SIDOSRYHMA.FI}</Label>
+            <Content>{perustelut.sidosryhma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>
+            <Content>{perustelut.vuodet.arvo_1.vuosi} {perustelut.vuodet.arvo_1.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_2.vuosi} {perustelut.vuodet.arvo_2.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_3.vuosi} {perustelut.vuodet.arvo_3.maara || perusteluText} </Content>
+          </Area>
+        </PerusteluInner>
+      </PerusteluWrapper>
+    )
+  }
+}
+
+export default PerusteluSimple

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
@@ -187,7 +187,7 @@ class PerusteluTyovoima extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_tyovoima.vuodet.arvo_2.vuosi = vuosi
+                obj.meta.perusteluteksti_tyovoima.vuodet.arvo_2.vuosi = parseFloat(vuosi) + 1
                 obj.meta.perusteluteksti_tyovoima.vuodet.arvo_2.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
@@ -200,7 +200,7 @@ class PerusteluTyovoima extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_tyovoima.vuodet.arvo_3.vuosi = vuosi
+                obj.meta.perusteluteksti_tyovoima.vuodet.arvo_3.vuosi = parseFloat(vuosi) + 2
                 obj.meta.perusteluteksti_tyovoima.vuodet.arvo_3.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativa.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativa.js
@@ -157,7 +157,7 @@ class PerusteluVaativa extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_vaativa.vuodet.arvo_2.vuosi = vuosi
+                obj.meta.perusteluteksti_vaativa.vuodet.arvo_2.vuosi = parseFloat(vuosi) + 1
                 obj.meta.perusteluteksti_vaativa.vuodet.arvo_2.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
@@ -170,7 +170,7 @@ class PerusteluVaativa extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_vaativa.vuodet.arvo_3.vuosi = vuosi
+                obj.meta.perusteluteksti_vaativa.vuodet.arvo_3.vuosi = parseFloat(vuosi) + 2
                 obj.meta.perusteluteksti_vaativa.vuodet.arvo_3.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
@@ -162,7 +162,7 @@ class PerusteluVankila extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_vankila.vuodet.arvo_2.vuosi = vuosi
+                obj.meta.perusteluteksti_vankila.vuodet.arvo_2.vuosi = parseFloat(vuosi) + 1
                 obj.meta.perusteluteksti_vankila.vuodet.arvo_2.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
@@ -174,7 +174,7 @@ class PerusteluVankila extends Component {
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_vankila.vuodet.arvo_3.vuosi = vuosi
+                obj.meta.perusteluteksti_vankila.vuodet.arvo_3.vuosi = parseFloat(vuosi) + 2
                 obj.meta.perusteluteksti_vankila.vuodet.arvo_3.maara = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)


### PR DESCRIPTION
Näytä oppisopimuskoulutuksen hakemiseen liittyvät perustelut muutospyynnön yhteenvedossa.

Perustelulomakkeista löytyi pieni bugi, joka tallensi kaikki kohdan "Arvio koulutukseen suunnattavista opiskelijavuosista seuraavana kolmena vuotena" vastaukset samalle vuosinumerolle. Korjattu muiden muutosten yhteydessä.