### PR TITLE
CSCOIVA-587: Näytä vankilakoulutuksen perustelut yhteenvedossa

### DIFF
--- a/src/modules/reducers/vankilat.js
+++ b/src/modules/reducers/vankilat.js
@@ -1,0 +1,71 @@
+import { API_BASE_URL } from "../constants"
+import { getVankilaList } from "../../routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil"
+
+// Constants
+export const FETCH_VANKILAT_START = 'FETCH_VANKILAT_START'
+export const FETCH_VANKILAT_SUCCESS = 'FETCH_VANKILAT_SUCCESS'
+export const FETCH_VANKILAT_FAILURE = 'FETCH_VANKILAT_FAILURE'
+
+// Actions
+export function fetchVankilat() {
+  return (dispatch) => {
+    dispatch({ type: FETCH_VANKILAT_START })
+
+    const request = fetch(`${API_BASE_URL}/koodistot/koodit/vankilat`)
+
+    request
+      .then(response => response.json())
+      .then(data => {
+        dispatch({ type: FETCH_VANKILAT_SUCCESS, payload: data })
+      })
+      .catch(err => dispatch({ type: FETCH_VANKILAT_FAILURE, payload: err }))
+  }
+}
+
+export const actions = {
+  fetchVankilat
+}
+
+// Action handlers
+const ACTION_HANDLERS = {
+  [FETCH_VANKILAT_START] : (state, action) => {
+    return {
+      ...state,
+      isFetching: true,
+      fetched: false,
+      hasErrored: false
+    }
+  },
+  [FETCH_VANKILAT_SUCCESS] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: true,
+      hasErrored: false,
+      data: action.payload,
+      vankilaList: getVankilaList(action.payload, 'FI')
+    }
+  },
+  [FETCH_VANKILAT_FAILURE] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: false,
+      hasErrored: true
+    }
+  }
+}
+
+// Reducer
+const initialState = {
+  isFetching: false,
+  fetched: false,
+  hasErrored: false,
+  data: []
+}
+
+export default function vankilatReducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+
+  return handler ? handler(state, action) : state
+}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 
 import PerusteluSimple from './PerusteluSimple'
+import PerusteluOppisopimusYhteenveto from './PerusteluOppisopimusYhteenveto'
 import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
@@ -89,15 +90,27 @@ class MuutosYhteenveto extends Component {
             <Indikaattori status="ok" text="Perusteltu" />
           }
         </MuutosTop>
-        <PerusteluSimple
-          helpText={helpText}
-          koodiarvo={koodiarvo}
-          perusteluteksti={perusteluteksti}
-          muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-          muutokset={muutokset}
-          muutos={muutos}
-          fields={fields}
-        />
+        { koodiarvo === "1" ? 
+          <PerusteluOppisopimusYhteenveto 
+            helpText={helpText}
+            koodiarvo={koodiarvo}
+            perustelut={meta.perusteluteksti_oppisopimus}
+            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+            muutokset={muutokset}
+            muutos={muutos}
+            fields={fields}
+          />
+         :
+          <PerusteluSimple
+            helpText={helpText}
+            koodiarvo={koodiarvo}
+            perusteluteksti={perusteluteksti}
+            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+            muutokset={muutokset}
+            muutos={muutos}
+            fields={fields}
+          />
+          }
       </MuutosWrapper>
     )
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -7,6 +7,7 @@ import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_TYPES, MUUTOS_TYPE_TEXTS } from "../modules/uusiHakemusFormConstants"
+import { KOODISTOT } from "../../../modules/constants"
 
 const MuutosWrapper = styled.div`
   width: 100%;
@@ -90,7 +91,7 @@ class MuutosYhteenveto extends Component {
             <Indikaattori status="ok" text="Perusteltu" />
           }
         </MuutosTop>
-        { koodiarvo === "1" ? 
+        { koodisto === KOODISTOT.OIVA_MUUT && koodiarvo === "1" && type === MUUTOS_TYPES.ADDITION ? 
           <PerusteluOppisopimusYhteenveto 
             helpText={helpText}
             koodiarvo={koodiarvo}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -103,7 +103,7 @@ class MuutosYhteenveto extends Component {
             fields={fields}
           />
          :
-         KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "5" || koodiarvo === "13") ?
+         koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "5" || koodiarvo === "13") ?
           <PerusteluVankilaYhteenveto 
             helpText={helpText}
             koodiarvo={koodiarvo}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import PerusteluSimple from './PerusteluSimple'
 import PerusteluOppisopimusYhteenveto from './PerusteluOppisopimusYhteenveto'
+import PerusteluVankilaYhteenveto from './PerusteluVankilaYhteenveto'
 import Indikaattori from './Indikaattori'
 
 import { COLORS } from "../../../../../../modules/styles"
@@ -91,7 +92,7 @@ class MuutosYhteenveto extends Component {
             <Indikaattori status="ok" text="Perusteltu" />
           }
         </MuutosTop>
-        { koodisto === KOODISTOT.OIVA_MUUT && koodiarvo === "1" && type === MUUTOS_TYPES.ADDITION ? 
+        { koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && koodiarvo === "1" ? 
           <PerusteluOppisopimusYhteenveto 
             helpText={helpText}
             koodiarvo={koodiarvo}
@@ -102,6 +103,17 @@ class MuutosYhteenveto extends Component {
             fields={fields}
           />
          :
+         KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "5" || koodiarvo === "13") ?
+          <PerusteluVankilaYhteenveto 
+            helpText={helpText}
+            koodiarvo={koodiarvo}
+            perustelut={meta.perusteluteksti_vankila}
+            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+            muutokset={muutokset}
+            muutos={muutos}
+            fields={fields}
+          />
+          :         
           <PerusteluSimple
             helpText={helpText}
             koodiarvo={koodiarvo}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
@@ -83,6 +83,7 @@ class MuutospyyntoEditWizard extends Component {
 
   componentWillMount() {
     this.props.fetchMuutosperustelut()
+    this.props.fetchVankilat()
     const { ytunnus, uuid } = this.props.match.params
     this.props.fetchLupa(ytunnus, '?with=all')
     this.props.fetchPaatoskierrokset()
@@ -176,7 +177,7 @@ class MuutospyyntoEditWizard extends Component {
   }
 
   render() {
-    const { muutosperustelut, lupa, paatoskierrokset, match, muutospyynto, initialValues } = this.props
+    const { muutosperustelut, vankilat, lupa, paatoskierrokset, match, muutospyynto, initialValues } = this.props
     const { page, visitedPages } = this.state
 
     // setTimeout(() => console.log(muutospyynto), 3000)
@@ -195,7 +196,7 @@ class MuutospyyntoEditWizard extends Component {
       )
     }
 
-    if (muutosperustelut.fetched && lupa.fetched && paatoskierrokset.fetched && muutospyynto.fetched) {
+    if (muutosperustelut.fetched && vankilat.fetched && lupa.fetched && paatoskierrokset.fetched && muutospyynto.fetched) {
       return (
         <div>
           <WizardBackground />
@@ -240,6 +241,7 @@ class MuutospyyntoEditWizard extends Component {
                     onCancel={this.onCancel}
                     save={this.save}
                     muutosperustelut={this.props.muutosperustelut.data}
+                    vankilat={this.props.vankilat.data}
                   />
                 )}
                 {page === 3 && (
@@ -272,10 +274,12 @@ class MuutospyyntoEditWizard extends Component {
           </Modal>
         </div>
       )
-    } else if (muutosperustelut.isFetching || lupa.isFetching || paatoskierrokset.isFetching || muutospyynto.isFetching) {
+    } else if (muutosperustelut.isFetching || vankilat.isFetching || lupa.isFetching || paatoskierrokset.isFetching || muutospyynto.isFetching) {
       return <Loading />
     } else if (muutosperustelut.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Muutosperusteluita ladattaessa tapahtui virhe.</div>
+    } else if (vankilat.hasErrored) {
+      return <div>Muutospyyntöä ei voida tehdä. Vankilalistausta ladattaessa tapahtui virhe.</div>
     } else if (paatoskierrokset.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Päätoskierroksia ladattaessa tapahtui virhe.</div>
     } else if (muutospyynto.hasErrored) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
@@ -91,6 +91,7 @@ class MuutospyyntoWizard extends Component {
 
   componentWillMount() {
     this.props.fetchMuutosperustelut()
+    this.props.fetchVankilat()
     const { ytunnus } = this.props.match.params
     this.props.fetchLupa(ytunnus, '?with=all')
     this.props.fetchPaatoskierrokset()
@@ -174,7 +175,7 @@ class MuutospyyntoWizard extends Component {
   }
 
   render() {
-    const { muutosperustelut, lupa, paatoskierrokset } = this.props
+    const { muutosperustelut, vankilat, lupa, paatoskierrokset } = this.props
     const { page, visitedPages } = this.state
 
     if (sessionStorage.getItem('role') !== ROLE_KAYTTAJA) {
@@ -191,7 +192,7 @@ class MuutospyyntoWizard extends Component {
         )
     }
 
-    if (muutosperustelut.fetched && lupa.fetched && paatoskierrokset.fetched) {
+    if (muutosperustelut.fetched && vankilat.fetched && lupa.fetched && paatoskierrokset.fetched) {
       return (
         <div>
           <WizardBackground />
@@ -235,6 +236,7 @@ class MuutospyyntoWizard extends Component {
                       onCancel={this.onCancel}
                       save={this.save}
                       muutosperustelut={this.props.muutosperustelut.data}
+                      vankilat={this.props.vankilat.data}
                     />
                   )}
                   {page === 3 && (
@@ -269,10 +271,12 @@ class MuutospyyntoWizard extends Component {
           </Modal>
         </div>
       )
-    } else if (muutosperustelut.isFetching || lupa.isFetching || paatoskierrokset.isFetching) {
+    } else if (muutosperustelut.isFetching || vankilat.isFetching || lupa.isFetching || paatoskierrokset.isFetching) {
       return <Loading />
     } else if (muutosperustelut.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Muutosperusteluita ladattaessa tapahtui virhe.</div>
+    } else if (vankilat.hasErrored) {
+      return <div>Muutospyyntöä ei voida tehdä. Vankilalistausta ladattaessa tapahtui virhe.</div>
     } else if (paatoskierrokset.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Päätoskierroksia ladattaessa tapahtui virhe.</div>
     } else if (lupa.hasErrored) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
@@ -70,8 +70,7 @@ class Perustelu extends Component {
     // koodisto on oiva muut
 
     // laajennettu oppisopimus
-//    if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
-// DEBUG: näytä aina
+   if (koodisto == KOODISTOT.OIVA_MUUT  && koodiarvo == 1 && (type === MUUTOS_TYPES.ADDITION || type === MUUTOS_TYPES.CHANGE )) {
       return (
         <PerusteluWrapper>
           <PerusteluOppisopimus
@@ -83,7 +82,7 @@ class Perustelu extends Component {
           />
         </PerusteluWrapper>
       )
-//    }
+   }
 
     // vaativa erityinen tuki
     // pitääkö tulla vain yksi perustelu-lomake, vaikka kaikki kolme eri vaihtoehtoa on valittu?

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
@@ -51,16 +51,21 @@ const LiiteTopArea = styled.div`
 
 class Perustelu extends Component {
   componentWillMount() {
-    const { muutosperustelut } = this.props
+    const { muutosperustelut, vankilat } = this.props
 
     if (muutosperustelut && !muutosperustelut.fetched) {
       this.props.fetchMuutosperustelut()
     }
+
+    if (vankilat && !vankilat.fetched) {
+      this.props.fetchVankilat()
+    }
+
   }
 
   render() {
 
-    const { helpText, muutos, muutokset, koodiarvo, fields, perusteluteksti, muutosperustelukoodiarvo, muutosperustelut } = this.props
+    const { helpText, muutos, muutokset, koodiarvo, fields, perusteluteksti, muutosperustelukoodiarvo, muutosperustelut, vankilat } = this.props
     const { perusteluteksti_oppisopimus, perusteluteksti_vaativa, perusteluteksti_tyovoima, perusteluteksti_vankila } = this.props
     const { perusteluteksti_kuljetus_perus, perusteluteksti_kuljetus_jatko, filename, file} = this.props
     const { koodisto, type } = muutos
@@ -131,6 +136,7 @@ class Perustelu extends Component {
             muutokset={muutokset}
             koodiarvo={koodiarvo}
             muutos={muutos}
+            vankilat={vankilat.vankilaList}
           />
         </PerusteluWrapper>
       )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+import { COLORS } from "../../../../../../modules/styles"
+import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+
+import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
+
+const PerusteluWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-left: 3px solid ${COLORS.BORDER_GRAY};
+  padding: 0 110px 0 30px;
+  margin: 10px 40px 20px 40px;
+`
+
+const PerusteluInner = styled.div`
+  background-color: ${COLORS.BG_GRAY};
+  padding: 10px 30px;
+`
+
+const Label = styled.div`
+  margin-bottom: 5px;
+`
+
+const Content = styled.div`
+  margin-left: 20px;
+  font-style: italic;
+`
+
+const Area = styled.div`
+  margin: 15px 0;
+`
+
+class PerusteluSimple extends Component {
+  componentWillMount() {
+    const { muutosperustelut } = this.props
+
+    if (muutosperustelut && !muutosperustelut.fetched) {
+      this.props.fetchMuutosperustelut()
+    }
+  }
+
+  render() {
+    const { perustelut, muutosperustelukoodiarvo } = this.props
+    let perusteluText = 'Ei saatavilla'
+    const perusteluObj = getMuutosperusteluByKoodiArvo(muutosperustelukoodiarvo)
+    if (perusteluObj) {
+      perusteluText = perusteluObj.label
+    }
+
+    return (
+      <PerusteluWrapper>
+        <PerusteluInner>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.TARPEELLISUUS.FI}</Label>
+            <Content>{perustelut.tarpeellisuus || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.OPPISOPIMUS.JARJESTAMISEDELLYTYKSET.FI}</Label>
+            <Content>{perustelut.henkilosto || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OSAAMINEN.FI}</Label>
+            <Content>{perustelut.osaaminen || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.SIDOSRYHMA.FI}</Label>
+            <Content>{perustelut.sidosryhma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>
+            <Content>{perustelut.vuodet.arvo_1.vuosi} {perustelut.vuodet.arvo_1.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_2.vuosi} {perustelut.vuodet.arvo_2.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_3.vuosi} {perustelut.vuodet.arvo_3.maara || perusteluText} </Content>
+          </Area>
+        </PerusteluInner>
+      </PerusteluWrapper>
+    )
+  }
+}
+
+export default PerusteluSimple

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
@@ -45,7 +45,7 @@ class PerusteluVankila extends Component {
       const vuosi = this.props.muutosperustelut.data[0].voimassaAlkuPvm.split("-")[0]
 
       const { muutokset, fields, koodiarvo, perusteluteksti_vankila, koodisto} = this.props
-      const { tarpeellisuus, henkilosto, osaaminen, pedagogiset, sidosryhma, suunnitelma, vuodet } = perusteluteksti_vankila
+      const { tarpeellisuus, henkilosto, osaaminen, pedagogiset, sidosryhma, vuodet } = perusteluteksti_vankila
       const { arvo_1, arvo_2, arvo_3 } = vuodet
 
       let { vankilat } = this.props

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
 import Select from '../../../../../../modules/Select'
-import { handleMuutosperusteluSelectChange } from "../modules/muutosperusteluUtil"
+import { handleVankilaSelectChange } from "../modules/vankilaUtil"
 
 const PerusteluVankilaWrapper = styled.div`
   margin-bottom: 20px;
@@ -31,14 +31,14 @@ class PerusteluVankila extends Component {
     constructor(props) {
       super(props)
       this.state = {
-        selectedOption: props.muutosperustelukoodiarvo
+        selectedOption: props.vankilakoodiarvo
       }
     }
 
     handleChange(selectedOption) {
       this.setState({ selectedOption })
       const { muutokset, fields, muutos } = this.props
-      handleMuutosperusteluSelectChange(muutokset, fields, muutos, selectedOption)
+      handleVankilaSelectChange(muutokset, fields, muutos, selectedOption)
     }
 
     render() {
@@ -128,7 +128,7 @@ class PerusteluVankila extends Component {
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.SUUNNITELMA.FI}</Label>
             <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.OHJEET.SUUNNITELMA.FI}</Instruction>
             <Select
-              name={`select-muutosperustelu-${koodisto}-${koodiarvo}`}
+              name={`select-vankila-${koodisto}-${koodiarvo}`}
               value={selectedOption}
               options={vankilat}
               onChange={this.handleChange.bind(this)}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
+import _ from 'lodash'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
 import Select from '../../../../../../modules/Select'
@@ -43,21 +44,13 @@ class PerusteluVankila extends Component {
     render() {
       const vuosi = this.props.muutosperustelut.data[0].voimassaAlkuPvm.split("-")[0]
 
-      const { muutokset, fields, koodiarvo, perusteluteksti_vankila, koodisto } = this.props
+      const { muutokset, fields, koodiarvo, perusteluteksti_vankila, koodisto} = this.props
       const { tarpeellisuus, henkilosto, osaaminen, pedagogiset, sidosryhma, suunnitelma, vuodet } = perusteluteksti_vankila
       const { arvo_1, arvo_2, arvo_3 } = vuodet
 
-      // vankilat hardcode
-      const options = [
-        { value: 'Helsingin vankila', label: 'Helsingin vankila' },
-        { value: 'Helsingin avovankila, Suomenlinnan osasto', label: 'Helsingin avovankila, Suomenlinnan osasto' },
-        { value: 'Helsingin avovankila, Vantaan osasto', label: 'Helsingin avovankila, Vantaan osasto' },
-        { value: 'Jokelan vankila, Tuusula', label: 'Jokelan vankila, Tuusula' },
-        { value: 'Keravan vankila, Kerava', label: 'Keravan vankila, Kerava' },
-        { value: 'Vanajan vankila (Avo-osastot Vanajalla ja Ojoisilla)', label: 'Vanajan vankila (Avo-osastot Vanajalla ja Ojoisilla)' },
-        { value: 'Riihimäen vankila, Riihimäki', label: 'Riihimäen vankila, Riihimäki' },
-        { value: 'Vantaan vankila, Vantaa (t.)', label: 'Vantaan vankila, Vantaa (t.)' },
-      ];
+      let { vankilat } = this.props
+      vankilat = _.sortBy(vankilat, v => { return v.label })
+      console.log(vankilat)
 
       const { selectedOption } = this.state
 
@@ -137,7 +130,7 @@ class PerusteluVankila extends Component {
             <Select
               name={`select-muutosperustelu-${koodisto}-${koodiarvo}`}
               value={selectedOption}
-              options={options}
+              options={vankilat}
               onChange={this.handleChange.bind(this)}
               placeholder="Valitse vankila..."
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
+import _ from 'lodash'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 
@@ -43,6 +44,7 @@ class PerusteluVankilaYhteenveto extends Component {
   render() {
     const { perustelut } = this.props
     let perusteluText = 'Ei saatavilla'
+    let vankilanMetaSuomeksi = _.find(perustelut.toteuttaminen.metadata, (m) => {return m.kieli === "FI"})
 
     return (
       <PerusteluWrapper>
@@ -69,7 +71,7 @@ class PerusteluVankilaYhteenveto extends Component {
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.TOTEUTTAMINEN.FI}</Label>
-            <Content>Ei vielä tietomallissa, toteutetaan myöhemmin</Content>
+            <Content>{vankilanMetaSuomeksi.nimi || perusteluText}</Content>
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+import { COLORS } from "../../../../../../modules/styles"
+import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+
+import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
+
+const PerusteluWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-left: 3px solid ${COLORS.BORDER_GRAY};
+  padding: 0 110px 0 30px;
+  margin: 10px 40px 20px 40px;
+`
+
+const PerusteluInner = styled.div`
+  background-color: ${COLORS.BG_GRAY};
+  padding: 10px 30px;
+`
+
+const Label = styled.div`
+  margin-bottom: 5px;
+`
+
+const Content = styled.div`
+  margin-left: 20px;
+  font-style: italic;
+`
+
+const Area = styled.div`
+  margin: 15px 0;
+`
+
+class PerusteluSimple extends Component {
+  componentWillMount() {
+    const { muutosperustelut } = this.props
+
+    if (muutosperustelut && !muutosperustelut.fetched) {
+      this.props.fetchMuutosperustelut()
+    }
+  }
+
+  render() {
+    const { perustelut, muutosperustelukoodiarvo } = this.props
+    let perusteluText = 'Ei saatavilla'
+    const perusteluObj = getMuutosperusteluByKoodiArvo(muutosperustelukoodiarvo)
+    if (perusteluObj) {
+      perusteluText = perusteluObj.label
+    }
+
+    return (
+      <PerusteluWrapper>
+        <PerusteluInner>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.TARPEELLISUUS.FI}</Label>
+            <Content>{perustelut.tarpeellisuus || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.JARJESTAMISEDELLYTYKSET.FI}</Label>
+            <Content>{perustelut.henkilosto || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OSAAMINEN.FI}</Label>
+            <Content>{perustelut.osaaminen || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.PEDAGOGISET.FI}</Label>
+            <Content>{perustelut.pedagogiset || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.SIDOSRYHMA.FI}</Label>
+            <Content>{perustelut.sidosryhma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.TOTEUTTAMINEN.FI}</Label>
+            <Content>Ei vielä tietomallissa, toteutetaan myöhemmin</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>
+            <Content>{perustelut.vuodet.arvo_1.vuosi} {perustelut.vuodet.arvo_1.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_2.vuosi} {perustelut.vuodet.arvo_2.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_3.vuosi} {perustelut.vuodet.arvo_3.maara || perusteluText} </Content>
+          </Area>
+        </PerusteluInner>
+      </PerusteluWrapper>
+    )
+  }
+}
+
+export default PerusteluSimple

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 
-import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
+// import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
 
 const PerusteluWrapper = styled.div`
   display: flex;
@@ -31,7 +31,7 @@ const Area = styled.div`
   margin: 15px 0;
 `
 
-class PerusteluSimple extends Component {
+class PerusteluVankilaYhteenveto extends Component {
   componentWillMount() {
     const { muutosperustelut } = this.props
 
@@ -41,12 +41,8 @@ class PerusteluSimple extends Component {
   }
 
   render() {
-    const { perustelut, muutosperustelukoodiarvo } = this.props
+    const { perustelut } = this.props
     let perusteluText = 'Ei saatavilla'
-    const perusteluObj = getMuutosperusteluByKoodiArvo(muutosperustelukoodiarvo)
-    if (perusteluObj) {
-      perusteluText = perusteluObj.label
-    }
 
     return (
       <PerusteluWrapper>
@@ -87,4 +83,4 @@ class PerusteluSimple extends Component {
   }
 }
 
-export default PerusteluSimple
+export default PerusteluVankilaYhteenveto

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
+import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
 import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto, fetchMuutospyynto, updateMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
@@ -15,6 +16,7 @@ import MuutospyyntoEditWizard from '../components/MuutospyyntoEditWizard'
 const mapStateToProps = (state) => {
   return {
     muutosperustelut: state.muutosperustelut,
+    vankilat: state.vankilat,
     lupa: state.lupa,
     koulutukset: state.koulutukset,
     paatoskierrokset: state.paatoskierrokset,
@@ -27,6 +29,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch, props) => {
   return {
     fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
+    fetchVankilat: () => dispatch(fetchVankilat()),
     fetchLupa: (ytunnus, query) => dispatch(fetchLupa(ytunnus, query)),
     createMuutospyynto: (muutospyynto) => dispatch(createMuutospyynto(muutospyynto)),
     saveMuutospyynto: (muutospyynto) => dispatch(saveMuutospyynto(muutospyynto)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
+import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
 import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
@@ -15,6 +16,7 @@ import MuutospyyntoWizard from '../components/MuutospyyntoWizard'
 const mapStateToProps = (state) => {
   return {
     muutosperustelut: state.muutosperustelut,
+    vankilat: state.vankilat,
     lupa: state.lupa,
     koulutukset: state.koulutukset,
     paatoskierrokset: state.paatoskierrokset,
@@ -27,6 +29,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch, props) => {
   return {
     fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
+    fetchVankilat: () => dispatch(fetchVankilat()),
     fetchLupa: (ytunnus, query) => dispatch(fetchLupa(ytunnus, query)),
     createMuutospyynto: (muutospyynto) => dispatch(createMuutospyynto(muutospyynto)),
     saveMuutospyynto: (muutospyynto) => dispatch(saveMuutospyynto(muutospyynto)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/PerusteluContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/PerusteluContainer.js
@@ -2,16 +2,19 @@ import { connect } from 'react-redux'
 
 import Perustelu from '../components/Perustelu'
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
+import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
 
 const mapStateToProps = (state) => {
   return {
-    muutosperustelut: state.muutosperustelut
+    muutosperustelut: state.muutosperustelut,
+    vankilat: state.vankilat
   }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut())
+    fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
+    fetchVankilat: () => dispatch(fetchVankilat())
   }
 }
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -271,6 +271,7 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
             "osaaminen": null,
             "sidosryhma": null,
             "pedagogiset": null,
+            "toteuttaminen": null,
             "vuodet": {
               "arvo_1": {"vuosi": null, "maara": null},
               "arvo_2": {"vuosi": null, "maara": null},
@@ -417,6 +418,7 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
               "osaaminen": null,
               "sidosryhma": null,
               "pedagogiset": null,
+              "toteuttaminen": null,
               "vuodet": {
                 "arvo_1": {"vuosi": null, "maara": null},
                 "arvo_2": {"vuosi": null, "maara": null},

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
-// import store from '../../../../../../store'
+import store from '../../../../../../store'
 
 export function getVankilaList(vankilat, locale) {
   let array = []
@@ -29,7 +29,10 @@ export function handleVankilaSelectChange(muutokset, fields, muutos, selectedVal
   if (i !== undefined) {
     let obj = fields.get(i)
     fields.remove(i)
-    obj.meta.perusteluteksti_vankila.toteuttaminen = vankilaValue
+    let vankila = getVankilaByKoodiArvo(vankilaValue)
+    obj.meta.perusteluteksti_vankila.toteuttaminen = _.pickBy(vankila, (value, key) => {
+    	return key === "koodiArvo" || key === "koodisto" || key === "versio" || key === "metadata"
+    })
     fields.insert(i, obj)
   }
 
@@ -47,14 +50,16 @@ function getVankilaEditIndex(muutokset, koodiarvo) {
   return i
 }
 
-// export function getMuutosperusteluByKoodiArvo(koodiarvo) {
-//   const state = store.getState()
+export function getVankilaByKoodiArvo(koodiarvo) {
+  const state = store.getState()
 
-//   const { muutosperustelut } = state
+  const { vankilat } = state
 
-//   if (muutosperustelut && muutosperustelut.fetched) {
-//     return _.find(muutosperustelut.muutosperusteluList, (muutosperustelu) => { return muutosperustelu.koodiArvo === koodiarvo })
-//   } else {
-//     return undefined
-//   }
-// }
+  if (vankilat && vankilat.fetched) {
+    return _.find(vankilat.vankilaList, (vankila) => { 
+    	return vankila.koodiArvo === koodiarvo
+    })
+  } else {
+    return undefined
+  }
+}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
@@ -1,0 +1,59 @@
+// import _ from 'lodash'
+import { parseLocalizedField } from "../../../../../../modules/helpers"
+// import store from '../../../../../../store'
+
+export function getVankilaList(vankilat, locale) {
+  let array = []
+
+  console.log("haen vankilalistaa")
+
+  vankilat.forEach(vankila => {
+    const { koodiArvo, metadata } = vankila
+    array.push({ ...vankila, label: parseLocalizedField(metadata, locale), value: koodiArvo })
+  })
+
+  return array
+}
+
+// export function handleMuutosperusteluSelectChange(muutokset, fields, muutos, selectedValue) {
+//   let muutosperusteluValue = null
+
+//   if (selectedValue !== null) {
+//     muutosperusteluValue = selectedValue.koodiArvo
+//   }
+
+//   const { koodiarvo } = muutos
+
+//   const i = getMuutosperusteluEditIndex(muutokset, koodiarvo)
+
+//   if (i !== undefined) {
+//     let obj = fields.get(i)
+//     fields.remove(i)
+//     obj.muutosperustelukoodiarvo = muutosperusteluValue
+//     fields.insert(i, obj)
+//   }
+// }
+
+// function getMuutosperusteluEditIndex(muutokset, koodiarvo) {
+//   let i = undefined
+
+//   _.forEach(muutokset, (muutos, idx) => {
+//     if (muutos.koodiarvo === koodiarvo) {
+//       i = idx
+//     }
+//   })
+
+//   return i
+// }
+
+// export function getMuutosperusteluByKoodiArvo(koodiarvo) {
+//   const state = store.getState()
+
+//   const { muutosperustelut } = state
+
+//   if (muutosperustelut && muutosperustelut.fetched) {
+//     return _.find(muutosperustelut.muutosperusteluList, (muutosperustelu) => { return muutosperustelu.koodiArvo === koodiarvo })
+//   } else {
+//     return undefined
+//   }
+// }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
@@ -1,4 +1,4 @@
-// import _ from 'lodash'
+import _ from 'lodash'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 // import store from '../../../../../../store'
 
@@ -15,36 +15,37 @@ export function getVankilaList(vankilat, locale) {
   return array
 }
 
-// export function handleMuutosperusteluSelectChange(muutokset, fields, muutos, selectedValue) {
-//   let muutosperusteluValue = null
+export function handleVankilaSelectChange(muutokset, fields, muutos, selectedValue) {
+  let vankilaValue = null
 
-//   if (selectedValue !== null) {
-//     muutosperusteluValue = selectedValue.koodiArvo
-//   }
+  if (selectedValue !== null) {
+    vankilaValue = selectedValue.koodiArvo
+  }
 
-//   const { koodiarvo } = muutos
+  const { koodiarvo } = muutos
 
-//   const i = getMuutosperusteluEditIndex(muutokset, koodiarvo)
+  const i = getVankilaEditIndex(muutokset, koodiarvo)
 
-//   if (i !== undefined) {
-//     let obj = fields.get(i)
-//     fields.remove(i)
-//     obj.muutosperustelukoodiarvo = muutosperusteluValue
-//     fields.insert(i, obj)
-//   }
-// }
+  if (i !== undefined) {
+    let obj = fields.get(i)
+    fields.remove(i)
+    obj.meta.perusteluteksti_vankila.toteuttaminen = vankilaValue
+    fields.insert(i, obj)
+  }
 
-// function getMuutosperusteluEditIndex(muutokset, koodiarvo) {
-//   let i = undefined
+}
 
-//   _.forEach(muutokset, (muutos, idx) => {
-//     if (muutos.koodiarvo === koodiarvo) {
-//       i = idx
-//     }
-//   })
+function getVankilaEditIndex(muutokset, koodiarvo) {
+  let i = undefined
 
-//   return i
-// }
+  _.forEach(muutokset, (muutos, idx) => {
+    if (muutos.koodiarvo === koodiarvo) {
+      i = idx
+    }
+  })
+
+  return i
+}
 
 // export function getMuutosperusteluByKoodiArvo(koodiarvo) {
 //   const state = store.getState()

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -7,6 +7,7 @@ import userReducer from '../routes/Login/modules/user'
 import muutospyynnotReducer from '../routes/Jarjestajat/Jarjestaja/Hakemukset/modules/muutospyynnot'
 import muutospyyntoReducer from '../routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/muutospyynto'
 import muutosperustelutReducer from '../modules/reducers/muutosperustelut'
+import vankilatReducer from '../modules/reducers/vankilat'
 import koulutusalatReducer from '../modules/reducers/koulutusalat'
 import koulutuksetReducer from '../modules/reducers/koulutukset'
 import paatoskierroksetReducer from '../modules/reducers/paatoskierrokset'
@@ -28,6 +29,7 @@ const rootReducer = combineReducers({
   muutospyynnot: muutospyynnotReducer,
   muutospyynto: muutospyyntoReducer,
   muutosperustelut: muutosperustelutReducer,
+  vankilat: vankilatReducer,
   koulutusalat: koulutusalatReducer,
   koulutukset: koulutuksetReducer,
   paatoskierrokset: paatoskierroksetReducer,


### PR DESCRIPTION
Näyttää yhteenvedossa vankilakoulutuksen perustelut.

Ei näytä vielä suunnitelma-kentän (dropdown vankiloista) arvoa, koska sitä ei ole toteutettu Reduxiin. Näyttää vankilan nimen paikalla placeholder-tekstin.