### PR TITLE
CSCOIVA-595: Työvoimakoulutuksen perustelut loppuun

### DIFF
--- a/src/modules/reducers/elykeskukset.js
+++ b/src/modules/reducers/elykeskukset.js
@@ -1,0 +1,71 @@
+import { API_BASE_URL } from "../constants"
+import { getELYkeskusList } from "../../routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/ELYkeskusUtil"
+
+// Constants
+export const FETCH_ELYKESKUKSET_START = 'FETCH_ELYKESKUKSET_START'
+export const FETCH_ELYKESKUKSET_SUCCESS = 'FETCH_ELYKESKUKSET_SUCCESS'
+export const FETCH_ELYKESKUKSET_FAILURE = 'FETCH_ELYKESKUKSET_FAILURE'
+
+// Actions
+export function fetchELYkeskukset() {
+  return (dispatch) => {
+    dispatch({ type: FETCH_ELYKESKUKSET_START })
+
+    const request = fetch(`${API_BASE_URL}/koodistot/koodit/elykeskukset`)
+
+    request
+      .then(response => response.json())
+      .then(data => {
+        dispatch({ type: FETCH_ELYKESKUKSET_SUCCESS, payload: data })
+      })
+      .catch(err => dispatch({ type: FETCH_ELYKESKUKSET_FAILURE, payload: err }))
+  }
+}
+
+export const actions = {
+  fetchELYkeskukset
+}
+
+// Action handlers
+const ACTION_HANDLERS = {
+  [FETCH_ELYKESKUKSET_START] : (state, action) => {
+    return {
+      ...state,
+      isFetching: true,
+      fetched: false,
+      hasErrored: false
+    }
+  },
+  [FETCH_ELYKESKUKSET_SUCCESS] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: true,
+      hasErrored: false,
+      data: action.payload,
+      ELYkeskusList: getELYkeskusList(action.payload, 'FI')
+    }
+  },
+  [FETCH_ELYKESKUKSET_FAILURE] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: false,
+      hasErrored: true
+    }
+  }
+}
+
+// Reducer
+const initialState = {
+  isFetching: false,
+  fetched: false,
+  hasErrored: false,
+  data: []
+}
+
+export default function ELYkeskuksetReducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+
+  return handler ? handler(state, action) : state
+}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import PerusteluSimple from './PerusteluSimple'
 import PerusteluOppisopimusYhteenveto from './PerusteluOppisopimusYhteenveto'
+import PerusteluTyovoimaYhteenveto from './PerusteluTyovoimaYhteenveto'
 import PerusteluVaativaYhteenveto from './PerusteluVaativaYhteenveto'
 import PerusteluVankilaYhteenveto from './PerusteluVankilaYhteenveto'
 import Indikaattori from './Indikaattori'
@@ -115,26 +116,37 @@ class MuutosYhteenveto extends Component {
               fields={fields}
             />
           :         
-           koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "3" || koodiarvo === "2" || koodiarvo === "12") ?
-            <PerusteluVaativaYhteenveto 
-              helpText={helpText}
-              koodiarvo={koodiarvo}
-              perustelut={meta.perusteluteksti_vaativa}
-              muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-              muutokset={muutokset}
-              muutos={muutos}
-              fields={fields}
-            />
+            koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "3" || koodiarvo === "2" || koodiarvo === "12") ?
+              <PerusteluVaativaYhteenveto 
+                helpText={helpText}
+                koodiarvo={koodiarvo}
+                perustelut={meta.perusteluteksti_vaativa}
+                muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+                muutokset={muutokset}
+                muutos={muutos}
+                fields={fields}
+              />
             :
-            <PerusteluSimple
-              helpText={helpText}
-              koodiarvo={koodiarvo}
-              perusteluteksti={perusteluteksti}
-              muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-              muutokset={muutokset}
-              muutos={muutos}
-              fields={fields}
-            />
+              koodisto === KOODISTOT.OIVA_TYOVOIMAKOULUTUS && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "3" || koodiarvo === "1") ?
+                <PerusteluTyovoimaYhteenveto 
+                  helpText={helpText}
+                  koodiarvo={koodiarvo}
+                  perustelut={meta.perusteluteksti_tyovoima}
+                  muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+                  muutokset={muutokset}
+                  muutos={muutos}
+                  fields={fields}
+                />
+              :
+                <PerusteluSimple
+                  helpText={helpText}
+                  koodiarvo={koodiarvo}
+                  perusteluteksti={perusteluteksti}
+                  muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+                  muutokset={muutokset}
+                  muutos={muutos}
+                  fields={fields}
+                />
           }
       </MuutosWrapper>
     )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosYhteenveto.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import PerusteluSimple from './PerusteluSimple'
 import PerusteluOppisopimusYhteenveto from './PerusteluOppisopimusYhteenveto'
+import PerusteluVaativaYhteenveto from './PerusteluVaativaYhteenveto'
 import PerusteluVankilaYhteenveto from './PerusteluVankilaYhteenveto'
 import Indikaattori from './Indikaattori'
 
@@ -102,27 +103,38 @@ class MuutosYhteenveto extends Component {
             muutos={muutos}
             fields={fields}
           />
-         :
-         koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "5" || koodiarvo === "13") ?
-          <PerusteluVankilaYhteenveto 
-            helpText={helpText}
-            koodiarvo={koodiarvo}
-            perustelut={meta.perusteluteksti_vankila}
-            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-            muutokset={muutokset}
-            muutos={muutos}
-            fields={fields}
-          />
+          :
+          koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "5" || koodiarvo === "13") ?
+            <PerusteluVankilaYhteenveto 
+              helpText={helpText}
+              koodiarvo={koodiarvo}
+              perustelut={meta.perusteluteksti_vankila}
+              muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+              muutokset={muutokset}
+              muutos={muutos}
+              fields={fields}
+            />
           :         
-          <PerusteluSimple
-            helpText={helpText}
-            koodiarvo={koodiarvo}
-            perusteluteksti={perusteluteksti}
-            muutosperustelukoodiarvo={muutosperustelukoodiarvo}
-            muutokset={muutokset}
-            muutos={muutos}
-            fields={fields}
-          />
+           koodisto === KOODISTOT.OIVA_MUUT && type === MUUTOS_TYPES.ADDITION && (koodiarvo === "3" || koodiarvo === "2" || koodiarvo === "12") ?
+            <PerusteluVaativaYhteenveto 
+              helpText={helpText}
+              koodiarvo={koodiarvo}
+              perustelut={meta.perusteluteksti_vaativa}
+              muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+              muutokset={muutokset}
+              muutos={muutos}
+              fields={fields}
+            />
+            :
+            <PerusteluSimple
+              helpText={helpText}
+              koodiarvo={koodiarvo}
+              perusteluteksti={perusteluteksti}
+              muutosperustelukoodiarvo={muutosperustelukoodiarvo}
+              muutokset={muutokset}
+              muutos={muutos}
+              fields={fields}
+            />
           }
       </MuutosWrapper>
     )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
@@ -84,6 +84,7 @@ class MuutospyyntoEditWizard extends Component {
   componentWillMount() {
     this.props.fetchMuutosperustelut()
     this.props.fetchVankilat()
+    this.props.fetchELYkeskukset()
     const { ytunnus, uuid } = this.props.match.params
     this.props.fetchLupa(ytunnus, '?with=all')
     this.props.fetchPaatoskierrokset()
@@ -177,7 +178,7 @@ class MuutospyyntoEditWizard extends Component {
   }
 
   render() {
-    const { muutosperustelut, vankilat, lupa, paatoskierrokset, match, muutospyynto, initialValues } = this.props
+    const { muutosperustelut, vankilat, ELYkeskukset, lupa, paatoskierrokset, match, muutospyynto, initialValues } = this.props
     const { page, visitedPages } = this.state
 
     // setTimeout(() => console.log(muutospyynto), 3000)
@@ -196,7 +197,7 @@ class MuutospyyntoEditWizard extends Component {
       )
     }
 
-    if (muutosperustelut.fetched && vankilat.fetched && lupa.fetched && paatoskierrokset.fetched && muutospyynto.fetched) {
+    if (muutosperustelut.fetched && vankilat.fetched && ELYkeskukset.fetched && lupa.fetched && paatoskierrokset.fetched && muutospyynto.fetched) {
       return (
         <div>
           <WizardBackground />
@@ -242,6 +243,7 @@ class MuutospyyntoEditWizard extends Component {
                     save={this.save}
                     muutosperustelut={this.props.muutosperustelut.data}
                     vankilat={this.props.vankilat.data}
+                    ELYkeskukset={this.props.ELYkeskukset.data}
                   />
                 )}
                 {page === 3 && (
@@ -274,12 +276,14 @@ class MuutospyyntoEditWizard extends Component {
           </Modal>
         </div>
       )
-    } else if (muutosperustelut.isFetching || vankilat.isFetching || lupa.isFetching || paatoskierrokset.isFetching || muutospyynto.isFetching) {
+    } else if (muutosperustelut.isFetching || vankilat.isFetching || ELYkeskukset.isFetching || lupa.isFetching || paatoskierrokset.isFetching || muutospyynto.isFetching) {
       return <Loading />
     } else if (muutosperustelut.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Muutosperusteluita ladattaessa tapahtui virhe.</div>
     } else if (vankilat.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Vankilalistausta ladattaessa tapahtui virhe.</div>
+    } else if (ELYkeskukset.hasErrored) {
+      return <div>Muutospyyntöä ei voida tehdä. ELY-keskuslistausta ladattaessa tapahtui virhe.</div>
     } else if (paatoskierrokset.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Päätoskierroksia ladattaessa tapahtui virhe.</div>
     } else if (muutospyynto.hasErrored) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
@@ -92,6 +92,7 @@ class MuutospyyntoWizard extends Component {
   componentWillMount() {
     this.props.fetchMuutosperustelut()
     this.props.fetchVankilat()
+    this.props.fetchELYkeskukset()
     const { ytunnus } = this.props.match.params
     this.props.fetchLupa(ytunnus, '?with=all')
     this.props.fetchPaatoskierrokset()
@@ -175,7 +176,7 @@ class MuutospyyntoWizard extends Component {
   }
 
   render() {
-    const { muutosperustelut, vankilat, lupa, paatoskierrokset } = this.props
+    const { muutosperustelut, vankilat, ELYkeskukset, lupa, paatoskierrokset } = this.props
     const { page, visitedPages } = this.state
 
     if (sessionStorage.getItem('role') !== ROLE_KAYTTAJA) {
@@ -192,7 +193,7 @@ class MuutospyyntoWizard extends Component {
         )
     }
 
-    if (muutosperustelut.fetched && vankilat.fetched && lupa.fetched && paatoskierrokset.fetched) {
+    if (muutosperustelut.fetched && vankilat.fetched && ELYkeskukset.fetched && lupa.fetched && paatoskierrokset.fetched) {
       return (
         <div>
           <WizardBackground />
@@ -237,6 +238,7 @@ class MuutospyyntoWizard extends Component {
                       save={this.save}
                       muutosperustelut={this.props.muutosperustelut.data}
                       vankilat={this.props.vankilat.data}
+                      ELYkeskukset={this.props.ELYkeskukset.data}
                     />
                   )}
                   {page === 3 && (
@@ -271,12 +273,14 @@ class MuutospyyntoWizard extends Component {
           </Modal>
         </div>
       )
-    } else if (muutosperustelut.isFetching || vankilat.isFetching || lupa.isFetching || paatoskierrokset.isFetching) {
+    } else if (muutosperustelut.isFetching || vankilat.isFetching || ELYkeskukset.isFetching || lupa.isFetching || paatoskierrokset.isFetching) {
       return <Loading />
     } else if (muutosperustelut.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Muutosperusteluita ladattaessa tapahtui virhe.</div>
     } else if (vankilat.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Vankilalistausta ladattaessa tapahtui virhe.</div>
+    } else if (ELYkeskukset.hasErrored) {
+      return <div>Muutospyyntöä ei voida tehdä. ELY-keskuslistausta ladattaessa tapahtui virhe.</div>
     } else if (paatoskierrokset.hasErrored) {
       return <div>Muutospyyntöä ei voida tehdä. Päätoskierroksia ladattaessa tapahtui virhe.</div>
     } else if (lupa.hasErrored) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Perustelu.js
@@ -51,7 +51,7 @@ const LiiteTopArea = styled.div`
 
 class Perustelu extends Component {
   componentWillMount() {
-    const { muutosperustelut, vankilat } = this.props
+    const { muutosperustelut, vankilat, ELYkeskukset } = this.props
 
     if (muutosperustelut && !muutosperustelut.fetched) {
       this.props.fetchMuutosperustelut()
@@ -61,11 +61,15 @@ class Perustelu extends Component {
       this.props.fetchVankilat()
     }
 
+    if (ELYkeskukset && !ELYkeskukset.fetched) {
+      this.props.fetchELYkeskukset()
+    }
+
   }
 
   render() {
 
-    const { helpText, muutos, muutokset, koodiarvo, fields, perusteluteksti, muutosperustelukoodiarvo, muutosperustelut, vankilat } = this.props
+    const { helpText, muutos, muutokset, koodiarvo, fields, perusteluteksti, muutosperustelukoodiarvo, muutosperustelut, vankilat, ELYkeskukset } = this.props
     const { perusteluteksti_oppisopimus, perusteluteksti_vaativa, perusteluteksti_tyovoima, perusteluteksti_vankila } = this.props
     const { perusteluteksti_kuljetus_perus, perusteluteksti_kuljetus_jatko, filename, file} = this.props
     const { koodisto, type } = muutos
@@ -120,6 +124,7 @@ class Perustelu extends Component {
             muutokset={muutokset}
             koodiarvo={koodiarvo}
             muutos={muutos}
+            ELYkeskukset={ELYkeskukset.ELYkeskusList}
           />
         </PerusteluWrapper>
       )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
+import _ from 'lodash'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
 import Select from '../../../../../../modules/Select'
-import { handleMuutosperusteluSelectChange } from "../modules/muutosperusteluUtil"
+import { handleELYkeskusSelectChange } from "../modules/ELYkeskusUtil"
 
 const PerusteluTyovoimaWrapper = styled.div`
   margin-bottom: 20px;
@@ -31,45 +32,32 @@ class PerusteluTyovoima extends Component {
     constructor(props) {
       super(props)
       this.state = {
-        selectedOption: props.muutosperustelukoodiarvo
+        selectedOption: props.ELYkeskuskoodiarvo
       }
     }
 
     handleChange(selectedOption) {
       this.setState({ selectedOption })
       const { muutokset, fields, muutos } = this.props
-      handleMuutosperusteluSelectChange(muutokset, fields, muutos, selectedOption)
+      handleELYkeskusSelectChange(muutokset, fields, muutos, selectedOption)
     }
 
     render() {
       const vuosi = this.props.muutosperustelut.data[0].voimassaAlkuPvm.split("-")[0]
 
       const { muutokset, fields, koodiarvo, perusteluteksti_tyovoima, koodisto } = this.props
-
-      console.log("teksti: " + JSON.stringify(perusteluteksti_tyovoima))
       const { tarpeellisuus, henkilosto, osaaminen, pedagogiset, sidosryhma, suunnitelma, vuodet } = perusteluteksti_tyovoima
       const { arvo_1, arvo_2, arvo_3 } = vuodet
 
-      // ELY-keskukset hardcode
-      const options = [
-        { value: 'Etelä-Pohjanmaa', label: 'Etelä-Pohjanmaa' },
-        { value: 'Etelä-Savo', label: 'Etelä-Savo' },
-        { value: 'Häme', label: 'Häme' },
-        { value: 'Kaakkois-Suomi', label: 'Kaakkois-Suomi' },
-        { value: 'Kainuu', label: 'Kainuu' },
-        { value: 'Keski-Suomi', label: 'Keski-Suomi' },
-        { value: 'Lappi', label: 'Lappi' },
-        { value: 'Pirkanmaa', label: 'Pirkanmaa' },
-        { value: 'Pohjanmaa', label: 'Pohjanmaa' },
-        { value: 'Pohjois-Karjala', label: 'Pohjois-Karjala' },
-        { value: 'Pohjois-Pohjanmaa', label: 'Pohjois-Pohjanmaa' },
-        { value: 'Pohjois-Savo', label: 'Pohjois-Savo'},
-        { value: 'Satakunta', label: 'Satakunta' },
-        { value: 'Uusimaa', label: 'Uusimaa' },
-        { value: 'Varsinais-Suomi', label: 'Varsinais-Suomi' }
-      ];
-      const { selectedOption } = this.state
-
+      let { ELYkeskukset } = this.props
+      // järjestä suomenkielisen nimen mukaan
+      ELYkeskukset = _.sortBy(ELYkeskukset, (e) => { 
+        let nimi = ""
+        _.forEach(e.metadata, (m) => {
+          if (m.kieli === "FI") { nimi = m.nimi }
+        })
+        return nimi
+       })
 
       return (
         <PerusteluTyovoimaWrapper>
@@ -157,9 +145,9 @@ class PerusteluTyovoima extends Component {
             <h4>4. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.YHTEISTYO.FI}</h4>
             <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.OHJEET.YHTEISTYO.FI}</Instruction>
             <Select
-              name={`select-muutosperustelu-${koodisto}-${koodiarvo}`}
-              value={selectedOption}
-              options={options}
+              name={`select-ELYkeskus-${koodisto}-${koodiarvo}`}
+              value={this.state.selectedOption}
+              options={ELYkeskukset}
               onChange={this.handleChange.bind(this)}
               placeholder="Valitse ely-keskus..."
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+import _ from 'lodash'
+import { COLORS } from "../../../../../../modules/styles"
+import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+
+const PerusteluWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-left: 3px solid ${COLORS.BORDER_GRAY};
+  padding: 0 110px 0 30px;
+  margin: 10px 40px 20px 40px;
+`
+
+const PerusteluInner = styled.div`
+  background-color: ${COLORS.BG_GRAY};
+  padding: 10px 30px;
+`
+
+const Label = styled.div`
+  margin-bottom: 5px;
+`
+
+const Content = styled.div`
+  margin-left: 20px;
+  font-style: italic;
+`
+
+const Area = styled.div`
+  margin: 15px 0;
+`
+
+class PerusteluTyovoimaYhteenveto extends Component {
+  componentWillMount() {
+    const { muutosperustelut } = this.props
+
+    if (muutosperustelut && !muutosperustelut.fetched) {
+      this.props.fetchMuutosperustelut()
+    }
+  }
+
+  render() {
+    console.log(this.props)
+    const { perustelut } = this.props
+    let perusteluText = 'Ei saatavilla'
+    let tyovoimaMetaSuomeksi = _.find(perustelut.yhteistyo.metadata, (m) => {return m.kieli === "FI"})
+
+    return (
+      <PerusteluWrapper>
+        <PerusteluInner>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.TARPEELLISUUS.FI}</Label>
+            <Content>{perustelut.tarpeellisuus || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.JARJESTAMISEDELLYTYKSET.FI}</Label>
+            <Content>{perustelut.henkilosto || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OSAAMINEN.FI}</Label>
+            <Content>{perustelut.osaaminen || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.PEDAGOGISET.FI}</Label>
+            <Content>{perustelut.pedagogiset || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.SIDOSRYHMA.FI}</Label>
+            <Content>{perustelut.sidosryhma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.SUUNNITELMA.FI}</Label>
+            <Content>{perustelut.suunnitelma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.YHTEISTYO.FI}</Label>
+            <Content>{tyovoimaMetaSuomeksi.nimi || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>
+            <Content>{perustelut.vuodet.arvo_1.vuosi} {perustelut.vuodet.arvo_1.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_2.vuosi} {perustelut.vuodet.arvo_2.maara || perusteluText} </Content>
+            <Content>{perustelut.vuodet.arvo_3.vuosi} {perustelut.vuodet.arvo_3.maara || perusteluText} </Content>
+          </Area>
+        </PerusteluInner>
+      </PerusteluWrapper>
+    )
+  }
+}
+
+export default PerusteluTyovoimaYhteenveto

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
@@ -40,10 +40,12 @@ class PerusteluTyovoimaYhteenveto extends Component {
   }
 
   render() {
-    console.log(this.props)
     const { perustelut } = this.props
     let perusteluText = 'Ei saatavilla'
-    let tyovoimaMetaSuomeksi = _.find(perustelut.yhteistyo.metadata, (m) => {return m.kieli === "FI"})
+    let tyovoimaMetaSuomeksi = null
+    if (perustelut.yhteistyo && 'metadata' in perustelut.yhteistyo) {
+      tyovoimaMetaSuomeksi = _.find(perustelut.yhteistyo.metadata, (m) => {return m.kieli === "FI"})
+    }
 
     return (
       <PerusteluWrapper>
@@ -74,7 +76,7 @@ class PerusteluTyovoimaYhteenveto extends Component {
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.TYOVOIMA.YHTEISTYO.FI}</Label>
-            <Content>{tyovoimaMetaSuomeksi.nimi || perusteluText}</Content>
+            <Content>{(tyovoimaMetaSuomeksi && 'nimi' in tyovoimaMetaSuomeksi && tyovoimaMetaSuomeksi.nimi) || perusteluText}</Content>
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativaYhteenveto.js
@@ -29,7 +29,7 @@ const Area = styled.div`
   margin: 15px 0;
 `
 
-class PerusteluOppisopimusYhteenveto extends Component {
+class PerusteluVaativaYhteenveto extends Component {
   render() {
     const { perustelut } = this.props
     let perusteluText = 'Ei saatavilla'
@@ -42,7 +42,7 @@ class PerusteluOppisopimusYhteenveto extends Component {
             <Content>{perustelut.tarpeellisuus || perusteluText}</Content>
           </Area>
           <Area>
-            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.OPPISOPIMUS.JARJESTAMISEDELLYTYKSET.FI}</Label>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VAATIVA.JARJESTAMISEDELLYTYKSET.FI}</Label>
             <Content>{perustelut.henkilosto || perusteluText}</Content>
           </Area>
           <Area>
@@ -50,8 +50,16 @@ class PerusteluOppisopimusYhteenveto extends Component {
             <Content>{perustelut.osaaminen || perusteluText}</Content>
           </Area>
           <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.PEDAGOGISET.FI}</Label>
+            <Content>{perustelut.pedagogiset || perusteluText}</Content>
+          </Area>
+          <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.SIDOSRYHMA.FI}</Label>
             <Content>{perustelut.sidosryhma || perusteluText}</Content>
+          </Area>
+          <Area>
+            <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VAATIVA.SUUNNITELMA.FI}</Label>
+            <Content>{perustelut.suunnitelma || perusteluText}</Content>
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>
@@ -65,4 +73,4 @@ class PerusteluOppisopimusYhteenveto extends Component {
   }
 }
 
-export default PerusteluOppisopimusYhteenveto
+export default PerusteluVaativaYhteenveto

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
@@ -44,7 +44,10 @@ class PerusteluVankilaYhteenveto extends Component {
   render() {
     const { perustelut } = this.props
     let perusteluText = 'Ei saatavilla'
-    let vankilanMetaSuomeksi = _.find(perustelut.toteuttaminen.metadata, (m) => {return m.kieli === "FI"})
+    let vankilanMetaSuomeksi = null
+    if (perustelut.toteuttaminen && 'metadata' in perustelut.toteuttaminen) {
+      vankilanMetaSuomeksi = _.find(perustelut.toteuttaminen.metadata, (m) => {return m.kieli === "FI"})
+    }
 
     return (
       <PerusteluWrapper>
@@ -71,7 +74,7 @@ class PerusteluVankilaYhteenveto extends Component {
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.VANKILA.TOTEUTTAMINEN.FI}</Label>
-            <Content>{vankilanMetaSuomeksi.nimi || perusteluText}</Content>
+            <Content>{(vankilanMetaSuomeksi && 'nimi' in vankilanMetaSuomeksi && vankilanMetaSuomeksi.nimi) || perusteluText}</Content>
           </Area>
           <Area>
             <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.OPISKELIJAVUOSIARVIO.FI}</Label>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
 import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
+import { fetchELYkeskukset } from "../../../../../../modules/reducers/elykeskukset"
 import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto, fetchMuutospyynto, updateMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
@@ -17,6 +18,7 @@ const mapStateToProps = (state) => {
   return {
     muutosperustelut: state.muutosperustelut,
     vankilat: state.vankilat,
+    ELYkeskukset: state.ELYkeskukset,
     lupa: state.lupa,
     koulutukset: state.koulutukset,
     paatoskierrokset: state.paatoskierrokset,
@@ -30,6 +32,7 @@ const mapDispatchToProps = (dispatch, props) => {
   return {
     fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
     fetchVankilat: () => dispatch(fetchVankilat()),
+    fetchELYkeskukset: () => dispatch(fetchELYkeskukset()),
     fetchLupa: (ytunnus, query) => dispatch(fetchLupa(ytunnus, query)),
     createMuutospyynto: (muutospyynto) => dispatch(createMuutospyynto(muutospyynto)),
     saveMuutospyynto: (muutospyynto) => dispatch(saveMuutospyynto(muutospyynto)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
 import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
+import { fetchELYkeskukset } from "../../../../../../modules/reducers/elykeskukset"
 import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
@@ -17,6 +18,7 @@ const mapStateToProps = (state) => {
   return {
     muutosperustelut: state.muutosperustelut,
     vankilat: state.vankilat,
+    ELYkeskukset: state.ELYkeskukset,
     lupa: state.lupa,
     koulutukset: state.koulutukset,
     paatoskierrokset: state.paatoskierrokset,
@@ -30,6 +32,7 @@ const mapDispatchToProps = (dispatch, props) => {
   return {
     fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
     fetchVankilat: () => dispatch(fetchVankilat()),
+    fetchELYkeskukset: () => dispatch(fetchELYkeskukset()),
     fetchLupa: (ytunnus, query) => dispatch(fetchLupa(ytunnus, query)),
     createMuutospyynto: (muutospyynto) => dispatch(createMuutospyynto(muutospyynto)),
     saveMuutospyynto: (muutospyynto) => dispatch(saveMuutospyynto(muutospyynto)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/PerusteluContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/PerusteluContainer.js
@@ -3,18 +3,21 @@ import { connect } from 'react-redux'
 import Perustelu from '../components/Perustelu'
 import { fetchMuutosperustelut } from "../../../../../../modules/reducers/muutosperustelut"
 import { fetchVankilat } from "../../../../../../modules/reducers/vankilat"
+import { fetchELYkeskukset } from "../../../../../../modules/reducers/elykeskukset"
 
 const mapStateToProps = (state) => {
   return {
     muutosperustelut: state.muutosperustelut,
-    vankilat: state.vankilat
+    vankilat: state.vankilat,
+    ELYkeskukset: state.ELYkeskukset,
   }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
     fetchMuutosperustelut: () => dispatch(fetchMuutosperustelut()),
-    fetchVankilat: () => dispatch(fetchVankilat())
+    fetchVankilat: () => dispatch(fetchVankilat()),
+    fetchELYkeskukset: () => dispatch(fetchELYkeskukset())
   }
 }
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/ELYkeskusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/ELYkeskusUtil.js
@@ -1,0 +1,63 @@
+import _ from 'lodash'
+import { parseLocalizedField } from "../../../../../../modules/helpers"
+import store from '../../../../../../store'
+
+export function getELYkeskusList(ELYkeskukset, locale) {
+  let array = []
+
+  ELYkeskukset.forEach(ELYkeskus => {
+    const { koodiArvo, metadata } = ELYkeskus
+    array.push({ ...ELYkeskus, label: parseLocalizedField(metadata, locale), value: koodiArvo })
+  })
+
+  return array
+}
+
+export function handleELYkeskusSelectChange(muutokset, fields, muutos, selectedValue) {
+  let ELYkeskusValue = null
+
+  if (selectedValue !== null) {
+    ELYkeskusValue = selectedValue.koodiArvo
+  }
+
+  const { koodiarvo } = muutos
+
+  const i = getELYkeskusEditIndex(muutokset, koodiarvo)
+
+  if (i !== undefined) {
+    let obj = fields.get(i)
+    fields.remove(i)
+    let ELYkeskus = getELYkeskusByKoodiArvo(ELYkeskusValue)
+    obj.meta.perusteluteksti_tyovoima.yhteistyo = _.pickBy(ELYkeskus, (value, key) => {
+    	return key === "koodiArvo" || key === "koodisto" || key === "versio" || key === "metadata"
+    })
+    fields.insert(i, obj)
+  }
+
+}
+
+function getELYkeskusEditIndex(muutokset, koodiarvo) {
+  let i = undefined
+
+  _.forEach(muutokset, (muutos, idx) => {
+    if (muutos.koodiarvo === koodiarvo) {
+      i = idx
+    }
+  })
+
+  return i
+}
+
+export function getELYkeskusByKoodiArvo(koodiarvo) {
+  const state = store.getState()
+
+  const { ELYkeskukset } = state
+
+  if (ELYkeskukset && ELYkeskukset.fetched) {
+    return _.find(ELYkeskukset.ELYkeskusList, (ELYkeskus) => { 
+    	return ELYkeskus.koodiArvo === koodiarvo
+    })
+  } else {
+    return undefined
+  }
+}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -283,6 +283,7 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
             "henkilosto": null,
             "osaaminen": null,
             "sidosryhma": null,
+            "yhteistyo": null,
             "vuodet": {
               "arvo_1": {"vuosi": null, "maara": null},
               "arvo_2": {"vuosi": null, "maara": null},
@@ -430,6 +431,7 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
               "henkilosto": null,
               "osaaminen": null,
               "sidosryhma": null,
+              "yhteistyo": null,
               "vuodet": {
                 "arvo_1": {"vuosi": null, "maara": null},
                 "arvo_2": {"vuosi": null, "maara": null},

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/vankilaUtil.js
@@ -5,8 +5,6 @@ import store from '../../../../../../store'
 export function getVankilaList(vankilat, locale) {
   let array = []
 
-  console.log("haen vankilalistaa")
-
   vankilat.forEach(vankila => {
     const { koodiArvo, metadata } = vankila
     array.push({ ...vankila, label: parseLocalizedField(metadata, locale), value: koodiArvo })

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -8,6 +8,7 @@ import muutospyynnotReducer from '../routes/Jarjestajat/Jarjestaja/Hakemukset/mo
 import muutospyyntoReducer from '../routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/muutospyynto'
 import muutosperustelutReducer from '../modules/reducers/muutosperustelut'
 import vankilatReducer from '../modules/reducers/vankilat'
+import ELYkeskuksetReducer from '../modules/reducers/elykeskukset'
 import koulutusalatReducer from '../modules/reducers/koulutusalat'
 import koulutuksetReducer from '../modules/reducers/koulutukset'
 import paatoskierroksetReducer from '../modules/reducers/paatoskierrokset'
@@ -30,6 +31,7 @@ const rootReducer = combineReducers({
   muutospyynto: muutospyyntoReducer,
   muutosperustelut: muutosperustelutReducer,
   vankilat: vankilatReducer,
+  ELYkeskukset: ELYkeskuksetReducer,
   koulutusalat: koulutusalatReducer,
   koulutukset: koulutuksetReducer,
   paatoskierrokset: paatoskierroksetReducer,


### PR DESCRIPTION
Työvoimakoulutuksen perusteluissa näytettävä lista ELY-keskuksista haetaan koodistosta. Valittu ELY-keskus tallennetaan formin stateen. Annetut perustelut näytetään yhteenvedossa.

Korjaa myös bugin, jossa yhteenveto heitti errorin, jos vankilakoulutuksen perusteluissa oli jätetty vankila valitsematta.