### PR TITLE
CSCOIVA-494: Edelleenohjaa kirjautunut käyttäjä organisaation sivulle

### DIFF
--- a/src/routes/Login/containers/CasAuthenticated.js
+++ b/src/routes/Login/containers/CasAuthenticated.js
@@ -48,12 +48,11 @@ class CasAuthenticated extends Component {
                   ?
                   <p>Kirjautumisessa tapahtui virhe</p>
                   :
-                  <Successful><h2>Tervetuloa Oiva-palveluun {sessionStorage.getItem('username')}</h2>
-                      <div><br/>Valitse organisaatio:<br/>
-                          <Link ytunnus={ytunnus} to={{pathname: "/jarjestajat/" + ytunnus + "/jarjestamislupa", ytunnus: ytunnus}}>{ytunnus} {nimi}</Link>
-                      </div>
-
-                  </Successful>
+                  ytunnus ?
+                    <Redirect ytunnus={ytunnus} to={{pathname: "/jarjestajat/" + ytunnus + "/jarjestamislupa", ytunnus: ytunnus}} />
+                    :
+                    <Successful><h2>Tervetuloa Oiva-palveluun {sessionStorage.getItem('username')}</h2>
+                    </Successful>
               }
           </div>
       )


### PR DESCRIPTION
Kun käyttäjä kirjautuu sisään, ohjaa hänet oman organisaation sivulle heti kun tieto tulee komponentin saataville. Jos käyttäjällä ei ole organisaatiota, näkyviin jää teksti "Tervetuloa Oiva-palveluun [käyttäjän nimi]".