### PR TITLE
CSCOIVA-512 Tutkintojen uudelleenjärjestys ja väliotsikointi

### DIFF
--- a/src/modules/reducers/koulutustyypit.js
+++ b/src/modules/reducers/koulutustyypit.js
@@ -1,0 +1,69 @@
+import { API_BASE_URL } from "../constants"
+
+// Constants
+export const FETCH_KOULUTUSTYYPIT_START = 'FETCH_KOULUTUSTYYPIT_START'
+export const FETCH_KOULUTUSTYYPIT_SUCCESS = 'FETCH_KOULUTUSTYYPIT_SUCCESS'
+export const FETCH_KOULUTUSTYYPIT_FAILURE = 'FETCH_KOULUTUSTYYPIT_FAILURE'
+
+// Actions
+export function fetchKoulutustyypit() {
+  return (dispatch) => {
+    dispatch({ type: FETCH_KOULUTUSTYYPIT_START })
+
+    const request = fetch(`${API_BASE_URL}/koodistot/koulutustyypit/`)
+
+    return request
+      .then(response => response.json())
+      .then(data => {
+        dispatch({ type: FETCH_KOULUTUSTYYPIT_SUCCESS, payload: data })
+      })
+      .catch(err => dispatch({ type: FETCH_KOULUTUSTYYPIT_FAILURE, payload: err }))
+  }
+}
+
+export const actions = {
+  fetchKoulutustyypit
+}
+
+// Action handlers
+const ACTION_HANDLERS = {
+  [FETCH_KOULUTUSTYYPIT_START] : (state, action) => {
+    return {
+      ...state,
+      isFetching: true,
+      fetched: false,
+      hasErrorer: false
+    }
+  },
+  [FETCH_KOULUTUSTYYPIT_SUCCESS] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: true,
+      hasErrored: false,
+      data: action.payload
+    }
+  },
+  [FETCH_KOULUTUSTYYPIT_FAILURE] : (state, action) => {
+    return {
+      ...state,
+      isFetching: false,
+      fetched: false,
+      hasErrored: true
+    }
+  }
+}
+
+// Reducer
+const initialState = {
+  isFetching: false,
+  fetched: false,
+  hasErrored: false,
+  data: []
+}
+
+export default function koulutustyypitReducer(state = initialState, action) {
+  const handler = ACTION_HANDLERS[action.type]
+
+  return handler ? handler(state, action) : state
+}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Muutos.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Muutos.js
@@ -75,7 +75,7 @@ class Muutos extends Component {
     const { isHidden } = this.state
     const { muutokset, muutos, fields, kategoria } = this.props
     const { koodiarvo, type, meta, muutosperustelukoodiarvo, koodisto, kuvaus, nimi, label, arvo, parentId } = muutos
-    const { perusteluteksti, perusteluteksti_oppisopimus, perusteluteksti_vaativa, perusteluteksti_tyovoima} = meta
+    const { perusteluteksti, perusteluteksti_oppisopimus, perusteluteksti_vaativa, perusteluteksti_tyovoima } = meta
     const { perusteluteksti_vankila, perusteluteksti_kuljetus_perus, perusteluteksti_kuljetus_jatko} = meta
 
     const helpText = "Perustele lyhyesti miksi tälle muutokselle on tarvetta"

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -18,11 +18,15 @@ const MuutosWrapper = styled.div`
 const MuutosAla = styled.div`
     margin: 10px 0 5px 0;
     width: 100%;
+    font-weight: bold;
 `
 
 const MuutosTyyppi = styled.div`
     margin: 10px 0 5px 0;
     width: 100%;
+    font-weight: bold;
+    font-size: 90%;
+    padding-left: 10px;
 `
 
 const Heading = styled.h4`

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 import Muutos from './Muutos'
 import MuutosYhteenveto from './MuutosYhteenveto'
 import { COMPONENT_TYPES } from "../modules/uusiHakemusFormConstants"
+import { getKoulutusalaByKoodiarvo, getKoulutustyyppiByKoodiarvo } from "../modules/koulutusUtil"
+import { parseLocalizedField } from "../../../../../../modules/helpers"
 
 const MuutosListWrapper = styled.div`
 `
@@ -54,18 +56,35 @@ class MuutosListTutkinnot extends Component {
         return 0
     })
 
+    // apumuuttujia alan ja tyypin vaihtumisen havaitsemiseen
+    var koulutusalaA = undefined
+    var koulutusalaB = undefined
+    var koulutustyyppiA = undefined
+    var koulutustyyppiB = undefined
+
     return (
       <MuutosListWrapper>
         {length > 0 &&
         <Heading>{`${headingNumber}. ${heading}`}</Heading>
         }
         {muutokset.map((field, index) => {
+          koulutusalaA = koulutusalaB
+          koulutustyyppiA = koulutustyyppiB
+        
           const muutos = fields.get(index)
-          const { koodiarvo, koodisto } = muutos
+          const { koodiarvo, koodisto, meta } = muutos
+          const { koulutusala, koulutustyyppi } = meta
+          koulutusalaB = koulutusala
+          koulutustyyppiB = koulutustyyppi
+
           const identifier = `muutoscomponent-${koodisto}-${koodiarvo}-${index}`
+          const koulutusalanNimiSuomeksi = parseLocalizedField(getKoulutusalaByKoodiarvo(koulutusala).metadata)
+          const koulutustyypinNimiSuomeksi = parseLocalizedField(getKoulutustyyppiByKoodiarvo(koulutustyyppi).metadata)
 
           return (
             <MuutosWrapper key={identifier}>
+              { koulutusala !== koulutusalaA && <MuutosAla>{ koulutusalanNimiSuomeksi }</MuutosAla> }
+              { (koulutusala !== koulutusalaA || koulutustyyppi !== koulutustyyppiA) && <MuutosTyyppi>{ koulutustyypinNimiSuomeksi }</MuutosTyyppi> }
               <MuutosComponent
                 key={index}
                 muutos={muutos}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import Muutos from './Muutos'
 import MuutosYhteenveto from './MuutosYhteenveto'
 import { COMPONENT_TYPES } from "../modules/uusiHakemusFormConstants"
-import { getKoulutusalaByKoodiarvo, getKoulutustyyppiByKoodiarvo } from "../modules/koulutusUtil"
+import { getKoulutusalaByKoodiarvo, getKoulutustyyppiByKoodiarvo, getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 
 const MuutosListWrapper = styled.div`
@@ -51,12 +51,25 @@ class MuutosListTutkinnot extends Component {
     }
 
     muutokset = muutokset.sort((a, b) => {
+    
+        // Osaamisalat aakkostetaan parent-tutkinnon kohdalle
+        a.aakkostusNimi = a.nimi
+        b.aakkostusNimi = b.nimi
+        if ("parentId" in a) {
+          a.aakkostusNimi = getTutkintoNimiByKoodiarvo(a.parentId)
+        }
+        if ("parentId" in b) {
+          b.aakkostusNimi = getTutkintoNimiByKoodiarvo(b.parentId)
+        }
+
         if (a.meta.koulutusala < b.meta.koulutusala) { return -1 }
         else if (a.meta.koulutusala > b.meta.koulutusala) { return 1 }
         else if (a.meta.koulutustyyppi < b.meta.koulutustyyppi) { return -1 }
         else if (a.meta.koulutustyyppi > b.meta.koulutustyyppi) { return 1 }
-        else if (a.meta.nimi < b.meta.nimi) { return -1 }
-        else if (a.meta.nimi > b.meta.nimi) { return 1 }
+        else if ("parentId" in a && a.parentId === b.koodiarvo) { return 1 }
+        else if ("parentId" in b && b.parentId === a.koodiarvo) { return -1 }
+        else if (a.aakkostusNimi < b.aakkostusNimi) { return -1 }
+        else if (a.aakkostusNimi > b.aakkostusNimi) { return 1 }
         return 0
     })
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
+
+import Muutos from './Muutos'
+import MuutosYhteenveto from './MuutosYhteenveto'
+import { COMPONENT_TYPES } from "../modules/uusiHakemusFormConstants"
+
+const MuutosListWrapper = styled.div`
+`
+
+const MuutosWrapper = styled.div`
+  margin-left: 30px;
+  flex-shrink: 0;
+`
+
+const MuutosAla = styled.div`
+    margin: 10px 0 5px 0;
+    width: 100%;
+`
+
+const MuutosTyyppi = styled.div`
+    margin: 10px 0 5px 0;
+    width: 100%;
+`
+
+const Heading = styled.h4`
+  margin: 18px 0;
+`
+
+const components = {
+  [COMPONENT_TYPES.MUUTOS]: Muutos,
+  [COMPONENT_TYPES.MUUTOS_YHTEENVETO]: MuutosYhteenveto
+}
+
+class MuutosListTutkinnot extends Component {
+  render() {
+
+    var { muutokset } = this.props
+    const { kategoria, fields, headingNumber, heading } = this.props
+    const { length } = fields
+    let { componentType } = this.props
+
+    if (!componentType) {
+      componentType = COMPONENT_TYPES.MUUTOS
+    }
+
+    muutokset = muutokset.sort((a, b) => {
+        if (a.meta.koulutusala < b.meta.koulutusala) { return -1 }
+        else if (a.meta.koulutusala > b.meta.koulutusala) { return 1 }
+        else if (a.meta.koulutustyyppi < b.meta.koulutustyyppi) { return -1 }
+        else if (a.meta.koulutustyyppi > b.meta.koulutustyyppi) { return 1 }
+        else if (a.meta.nimi < b.meta.nimi) { return -1 }
+        else if (a.meta.nimi > b.meta.nimi) { return 1 }
+        return 0
+    })
+
+    return (
+      <MuutosListWrapper>
+        {length > 0 &&
+        <Heading>{`${headingNumber}. ${heading}`}</Heading>
+        }
+        {muutokset.map((field, index) => {
+          const muutos = fields.get(index)
+          const { koodiarvo, koodisto } = muutos
+          const identifier = `muutoscomponent-${koodisto}-${koodiarvo}-${index}`
+
+          return (
+            <MuutosWrapper key={identifier}>
+              <MuutosComponent
+                key={index}
+                muutos={muutos}
+                muutokset={muutokset}
+                fields={fields}
+                kategoria={kategoria}
+                componentType={componentType}
+              />
+            </MuutosWrapper>
+          )
+        })}
+      </MuutosListWrapper>
+    )
+  }
+}
+
+const MuutosComponent = (props) => {
+  const MuutosSubComponent = components[props.componentType]
+  return <MuutosSubComponent {...props} />
+}
+
+export default MuutosListTutkinnot

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -5,7 +5,8 @@ import _ from 'lodash'
 import Muutos from './Muutos'
 import MuutosYhteenveto from './MuutosYhteenveto'
 import { COMPONENT_TYPES } from "../modules/uusiHakemusFormConstants"
-import { TUTKINNOT_SECTIONS } from "../../../modules/constants"
+import { TUTKINNOT_SECTIONS, KIELET_SECTIONS } from "../../../modules/constants"
+import { FIELD_ARRAY_NAMES} from "../modules/uusiHakemusFormConstants"
 import { getKoulutusalaByKoodiarvo, getKoulutustyyppiByKoodiarvo, getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 
@@ -47,7 +48,7 @@ const components = {
 class MuutosListTutkinnot extends Component {
   render() {
 
-    var { muutokset } = this.props
+    var { muutokset, nimi } = this.props
     const { kategoria, fields, headingNumber, heading } = this.props
     const { length } = fields
     let { componentType } = this.props
@@ -60,10 +61,14 @@ class MuutosListTutkinnot extends Component {
       m.indeksi = index
     })
 
-    var tutkinnot = _.filter(muutokset, (m) => {
-      return (m.koodisto === "koulutus" || m.koodisto === "osaamisala") && (m.koodiarvo !== "999901" && m.koodiarvo !== "999903")
+    var opetuskielet = _.filter(muutokset, (m) => {
+      return m.koodisto === "oppilaitoksenopetuskieli"
     })
+    opetuskielet = _.sortBy(opetuskielet, (k) => { return k.koodiarvo })
 
+    var tutkinnot = _.filter(muutokset, (m) => {
+      return (m.koodisto === "koulutus" || m.koodisto === "osaamisala" || m.koodisto === "kieli") && (m.koodiarvo !== "999901" && m.koodiarvo !== "999903")
+    })
     tutkinnot = tutkinnot.sort((a, b) => {
       // Apumuuttujat osaamisalojen järjestämiseen
       a.aakkostusNimi = a.nimi
@@ -117,9 +122,39 @@ class MuutosListTutkinnot extends Component {
         {length > 0 &&
         <Heading>{`${headingNumber}. ${heading}`}</Heading>
         }
+        { opetuskielet.length !== 0 &&
+          <div>
+            <SubHeading>{ KIELET_SECTIONS.OPETUSKIELET }</SubHeading>
+            {opetuskielet.map((field, index) => {
+              const muutos = fields.get(field.indeksi)
+              const { koodiarvo, koodisto } = muutos
+              const identifier = `muutoscomponent-${koodisto}-${koodiarvo}-${index}`
+
+              return (
+                <MuutosWrapper key={identifier}>
+                  <MuutosComponent
+                    key={index}
+                    muutos={muutos}
+                    muutokset={muutokset}
+                    fields={fields}
+                    kategoria={kategoria}
+                    componentType={componentType}
+                  />
+                </MuutosWrapper>
+              )
+            })}
+          </div>
+        }
         { tutkinnot.length !== 0 &&
           <div>
-            <SubHeading>{ TUTKINNOT_SECTIONS.TUTKINNOT }</SubHeading>
+            <SubHeading>
+              { nimi === FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET
+                ? TUTKINNOT_SECTIONS.TUTKINNOT
+                : nimi === FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET
+                  ? KIELET_SECTIONS.TUTKINTOKIELET
+                  : ""
+              }
+            </SubHeading>
             {tutkinnot.map((field, index) => {
               koulutusalaA = koulutusalaB
               koulutustyyppiA = koulutustyyppiB

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -82,13 +82,18 @@ class MuutosListTutkinnot extends Component {
           koulutustyyppiB = koulutustyyppi
 
           const identifier = `muutoscomponent-${koodisto}-${koodiarvo}-${index}`
-          const koulutusalanNimiSuomeksi = parseLocalizedField(getKoulutusalaByKoodiarvo(koulutusala).metadata)
-          const koulutustyypinNimiSuomeksi = parseLocalizedField(getKoulutustyyppiByKoodiarvo(koulutustyyppi).metadata)
+          var koulutusalanNimiSuomeksi = undefined
+          var koulutustyypinNimiSuomeksi = undefined
+
+          if (koulutusala) {
+              koulutusalanNimiSuomeksi = parseLocalizedField(getKoulutusalaByKoodiarvo(koulutusala).metadata)
+              koulutustyypinNimiSuomeksi = parseLocalizedField(getKoulutustyyppiByKoodiarvo(koulutustyyppi).metadata)
+          }
 
           return (
             <MuutosWrapper key={identifier}>
-              { koulutusala !== koulutusalaA && <MuutosAla>{ koulutusalanNimiSuomeksi }</MuutosAla> }
-              { (koulutusala !== koulutusalaA || koulutustyyppi !== koulutustyyppiA) && <MuutosTyyppi>{ koulutustyypinNimiSuomeksi }</MuutosTyyppi> }
+              { koulutusala && koulutusala !== koulutusalaA && <MuutosAla>{ koulutusalanNimiSuomeksi }</MuutosAla> }
+              { koulutusala && koulutustyyppi && (koulutusala !== koulutusalaA || koulutustyyppi !== koulutustyyppiA) && <MuutosTyyppi>{ koulutustyypinNimiSuomeksi }</MuutosTyyppi> }
               <MuutosComponent
                 key={index}
                 muutos={muutos}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
@@ -18,7 +18,7 @@ import close from 'static/images/close-x.svg'
 import { ROLE_KAYTTAJA } from "../../../../../../modules/constants";
 import { modalStyles, ModalButton, ModalText, Content } from "./ModalComponents"
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
-import { getJarjestajaData, loadFormData } from "../modules/muutospyyntoUtil"
+import { loadFormData } from "../modules/muutospyyntoUtil"
 
 Modal.setAppElement('#root')
 
@@ -153,11 +153,8 @@ class MuutospyyntoEditWizard extends Component {
       link.href = data;
       link.download="file.pdf";
       link.click();
-      setTimeout(function(){
-        // For Firefox it is necessary to delay revoking the ObjectURL
-        window.URL.revokeObjectURL(data)
-          , 100})
-
+      // For Firefox it is necessary to delay revoking the ObjectURL
+      setTimeout(window.URL.revokeObjectURL(data), 100)
     })
   }
 
@@ -178,7 +175,7 @@ class MuutospyyntoEditWizard extends Component {
   }
 
   render() {
-    const { muutosperustelut, vankilat, ELYkeskukset, lupa, paatoskierrokset, match, muutospyynto, initialValues } = this.props
+    const { muutosperustelut, vankilat, ELYkeskukset, lupa, paatoskierrokset, muutospyynto, initialValues } = this.props
     const { page, visitedPages } = this.state
 
     // setTimeout(() => console.log(muutospyynto), 3000)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoEditWizard.js
@@ -230,6 +230,7 @@ class MuutospyyntoEditWizard extends Component {
                     lupa={lupa}
                     initialValues={initialValues}
                     fetchKoulutusalat={this.props.fetchKoulutusalat}
+                    fetchKoulutustyypit={this.props.fetchKoulutustyypit}
                     fetchKoulutuksetAll={this.props.fetchKoulutuksetAll}
                     fetchKoulutuksetMuut={this.props.fetchKoulutuksetMuut}
                     fetchKoulutus={this.props.fetchKoulutus}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
@@ -151,10 +151,8 @@ class MuutospyyntoWizard extends Component {
           link.href = data;
           link.download="file.pdf";
           link.click();
-          setTimeout(function(){
           // For Firefox it is necessary to delay revoking the ObjectURL
-          window.URL.revokeObjectURL(data)
-              , 100})
+          setTimeout(window.URL.revokeObjectURL(data), 100)
 
       })
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
@@ -225,6 +225,7 @@ class MuutospyyntoWizard extends Component {
                       save={this.save}
                       lupa={lupa}
                       fetchKoulutusalat={this.props.fetchKoulutusalat}
+                      fetchKoulutustyypit={this.props.fetchKoulutustyypit}
                       fetchKoulutuksetAll={this.props.fetchKoulutuksetAll}
                       fetchKoulutuksetMuut={this.props.fetchKoulutuksetMuut}
                       fetchKoulutus={this.props.fetchKoulutus}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardComponents.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardComponents.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 import { COLORS, MEDIA_QUERIES, TRANSITIONS } from "../../../../../../modules/styles"
@@ -598,4 +597,12 @@ export const FormField = styled.div`
     max-width: 355px;
     width: 100%;
   }
+`
+export const KoulutustyyppiWrapper = styled.div`
+  margin: 5px 0 20px;
+`
+
+export const Koulutustyyppi = styled.div`
+  font-size: 15px;
+  font-weight: bold;
 `

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -30,17 +30,22 @@ class MuutospyyntoWizardMuutokset extends Component {
 
   componentWillMount() {
     // MuutospyyntoWIzardTutkinnot ja MuutospyyntoWizardTutkintokielet tarvitsevat listan tutkinnoista
-    if (!this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
+    if ((!this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) 
+      || (!this.props.koulutustyypit.fetched && !this.props.koulutustyypit.hasErrored)) {
       this.props.fetchKoulutusalat()
         .then(() => {
-          if (this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored) {
-            this.props.fetchKoulutuksetAll()
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.KULJETTAJAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.OIVA_TYOVOIMAKOULUTUS)
-            this.props.fetchKoulutuksetMuut(MUUT_KEYS.AMMATILLISEEN_TEHTAVAAN_VALMISTAVA_KOULUTUS)
-            this.props.fetchKoulutus("999901")
-            this.props.fetchKoulutus("999903")
-          }
+          this.props.fetchKoulutustyypit()
+            .then(() => {
+              if (this.props.koulutusalat.fetched && !this.props.koulutusalat.hasErrored && 
+                this.props.koulutustyypit.fetched && !this.props.koulutustyypit.hasErrored) {
+                this.props.fetchKoulutuksetAll()
+                this.props.fetchKoulutuksetMuut(MUUT_KEYS.KULJETTAJAKOULUTUS)
+                this.props.fetchKoulutuksetMuut(MUUT_KEYS.OIVA_TYOVOIMAKOULUTUS)
+                this.props.fetchKoulutuksetMuut(MUUT_KEYS.AMMATILLISEEN_TEHTAVAAN_VALMISTAVA_KOULUTUS)
+                this.props.fetchKoulutus("999901")
+                this.props.fetchKoulutus("999903")
+                }
+            })
         })
     }
   }
@@ -130,6 +135,7 @@ export default connect(state => {
 
   return {
     formValues: formVals,
-    koulutusalat: state.koulutusalat
+    koulutusalat: state.koulutusalat,
+    koulutustyypit: state.koulutustyypit
   }
 })(MuutospyyntoWizardMuutokset)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -52,9 +52,7 @@ class MuutospyyntoWizardMuutokset extends Component {
 
   render() {
     const {
-      onSubmit,
       save,
-//      update,
       lupa,
       formValues
     } = this.props

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
@@ -4,6 +4,7 @@ import { FieldArray, reduxForm, formValueSelector } from 'redux-form'
 import validate from '../modules/validateWizard'
 import { Separator, Button, SubtleButton, Container, WizardBottom } from './MuutospyyntoWizardComponents'
 import MuutosList from './MuutosList'
+import MuutosListTutkinnot from './MuutosListTutkinnot'
 
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { FIELD_ARRAY_NAMES, FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
@@ -35,7 +36,7 @@ let MuutospyyntoWizardPerustelut = props => {
           kategoria="tutkinto"
           headingNumber="1"
           heading="Tutkinnot ja koulutukset"
-          component={MuutosList}
+          component={MuutosListTutkinnot}
         />
 
         <FieldArray

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
@@ -32,6 +32,7 @@ let MuutospyyntoWizardPerustelut = props => {
       <form onSubmit={handleSubmit}>
         <FieldArray
           name={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
+          nimi={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
           muutokset={tutkinnotjakoulutuksetValue}
           kategoria="tutkinto"
           headingNumber="1"
@@ -41,11 +42,12 @@ let MuutospyyntoWizardPerustelut = props => {
 
         <FieldArray
           name={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
+          nimi={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
           muutokset={opetusjatutkintokieletValue}
           kategoria="opetuskieli"
           headingNumber="2"
           heading="Opetus- ja tutkintokielet"
-          component={MuutosList}
+          component={MuutosListTutkinnot}
         />
 
         <FieldArray

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardTutkinnot.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { FieldArray, reduxForm, formValueSelector } from 'redux-form'
 import validate from '../modules/validateWizard'
-import { TUTKINTO_TEKSTIT } from "../../../modules/constants"
+import { TUTKINTO_TEKSTIT, TUTKINNOT_SECTIONS } from "../../../modules/constants"
 import TutkintoList from './TutkintoList'
 import KoulutusList from './KoulutusList'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
@@ -128,7 +128,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
         <KoulutusList
           key="valmentavat"
           koodisto="koulutus"
-          nimi="Valmentavat koulutukset"
+          nimi={ TUTKINNOT_SECTIONS.POIKKEUKSET }
           koulutukset={poikkeukset}
           muutMaaraykset={muutMaaraykset}
           editValues={editValue}
@@ -139,7 +139,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
           <KoulutusList
             key="ammatilliseentehtavaanvalmistavakoulutus"
             koodisto="ammatilliseentehtavaanvalmistavakoulutus"
-            nimi="Ammatilliseen tehtävään valmistavat koulutukset"
+            nimi={ TUTKINNOT_SECTIONS.VALMISTAVAT }
             koulutukset={muut.ammatilliseentehtavaanvalmistavakoulutus}
             muutMaaraykset={muutMaaraykset}
             editValues={editValue}
@@ -151,7 +151,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
           <KoulutusList
             key="oivatyovoimakoulutus"
             koodisto="oivatyovoimakoulutus"
-            nimi="Työvoimakoulutukset"
+            nimi={ TUTKINNOT_SECTIONS.TYOVOIMAT }
             koulutukset={muut.oivatyovoimakoulutus}
             muutMaaraykset={muutMaaraykset}
             editValues={editValue}
@@ -163,7 +163,7 @@ class MuutospyyntoWizardTutkinnot extends Component {
           <KoulutusList
             key="kuljettajakoulutus"
             koodisto="kuljettajakoulutus"
-            nimi="Kuljettajakoulutukset"
+            nimi={ TUTKINNOT_SECTIONS.KULJETTAJAT }
             koulutukset={muut.kuljettajakoulutus}
             muutMaaraykset={muutMaaraykset}
             editValues={editValue}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
@@ -8,6 +8,7 @@ import Modal from 'react-modal'
 import OrganisaationTiedot from './OrganisaationTiedot'
 import DatePicker from "../../../../../../modules/DatePicker"
 import MuutosList from './MuutosList'
+import MuutosListTutkinnot from './MuutosListTutkinnot'
 
 import validate from '../modules/validateWizard'
 import { WizardBottom, Container, SubtleButton, Button, FormGroup, Label, FormField, Separator } from "./MuutospyyntoWizardComponents"
@@ -141,21 +142,23 @@ class MuutospyyntoWizardYhteenveto extends Component {
 
           <FieldArray
             name={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
+            nimi={FIELD_ARRAY_NAMES.TUTKINNOT_JA_KOULUTUKSET}
             muutokset={tutkinnotjakoulutuksetValue}
             kategoria="tutkinto"
             headingNumber="1"
             heading="Tutkinnot ja koulutukset"
-            component={MuutosList}
+            component={MuutosListTutkinnot}
             componentType={COMPONENT_TYPES.MUUTOS_YHTEENVETO}
           />
 
           <FieldArray
             name={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
+            nimi={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
             muutokset={opetusjatutkintokieletValue}
             kategoria="opetuskieli"
             headingNumber="2"
             heading="Opetus- ja tutkintokielet"
-            component={MuutosList}
+            component={MuutosListTutkinnot}
             componentType={COMPONENT_TYPES.MUUTOS_YHTEENVETO}
           />
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
@@ -13,7 +13,10 @@ import {
   KoulutusalaListWrapper,
   TutkintoWrapper,
   Koodi,
-  Nimi
+  Nimi,
+  Koulutustyyppi,
+  KoulutustyyppiWrapper,
+  TutkintoBlock
 } from './MuutospyyntoWizardComponents'
 import { handleTutkintoKieliCheckboxChange } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
@@ -82,10 +85,6 @@ class TutkintoKieliList extends Component {
       return 0;
     });
 
-    koulutukset = _.sortBy(koulutukset, k => {
-      return k.koodiArvo
-    })
-
     if (editValues) {
       _.forEach(editValues, value => {
         _.forEach(maaraykset, koulutus => {
@@ -95,6 +94,11 @@ class TutkintoKieliList extends Component {
         })
       })
     }
+
+    let koulutustyypit = []
+    _.forOwn(koulutukset, k => {
+      koulutustyypit.push(k)
+    })
 
     return (
       <Wrapper>
@@ -109,99 +113,107 @@ class TutkintoKieliList extends Component {
         </Heading>
         {!this.state.isHidden &&
         <KoulutusalaListWrapper>
-          {_.map(koulutukset, (koulutus, i) => {
-
-            const identifier = `input-tutkintokieli-2-${koulutus.koodiArvo}`
-            const nimiObjekti = _.filter(koulutus.metadata, (m) => { return m.kieli === "FI" })
-            const koulutuksenNimi = nimiObjekti[0].nimi
-
-            let isInLupa = false
-            let isAdded = false
-            let isRemoved = false
-            let isChanged = false
-            let isChecked = false
-            let valueKoodi = ""
-            let value = ""
-
-            tutkinnotjakielet.forEach(tutkintokieli => {
-              if (tutkintokieli.tutkintokoodi === koulutus.koodiArvo) {
-                isInLupa = true
-                valueKoodi = tutkintokieli.koodi
-              }
-            })
-
-            if (editValues) {
-              editValues.forEach(val => {
-                if (val.koodiarvo === koulutus.koodiArvo) {
-                  switch(val.type) {
-                    case MUUTOS_TYPES.ADDITION:
-                      valueKoodi = val.value
-                      isAdded = true
-                      break
-
-                    case MUUTOS_TYPES.REMOVAL:
-                      isRemoved = true
-                      break
-
-                    case MUUTOS_TYPES.CHANGE:
-                      isChanged = true
-                      break
-
-                    default:
-                      break
-                  }
-                }
-              })
-            }
-
-            let customClassName = isInLupa ? "is-in-lupa" : isAdded ? "is-added" : isRemoved ? "is-removed" : isChanged ? "is-changed" : null
-
-            if ((isInLupa && !isRemoved)) {
-              isChecked = true
-              value = valueKoodi
-            }
-
-            if (isAdded) {
-              isChecked = true
-              value = valueKoodi
-            }
-
-            if (isInLupa && isRemoved) {
-              value = ''
-            }
-
-            // Koulutus näytetään luvassa, jos se on (a) luvassa eikä sitä ole poistettu kohdassa 1 tai (b) lisätty kohdassa 1
-            let tutkinto = _.find(maaraykset, (m) => { return m.koodi === koulutus.koodiArvo })
-            if (!tutkinto) { tutkinto = _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.ADDITION}) }
-            if (!tutkinto || _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.REMOVAL})) { return false }
-
+          {_.map(koulutustyypit, (koulutustyyppi, i) => {
+            const koulutustyyppiSuomeksi = _.find(koulutustyyppi.metadata, (m) => {return m.kieli === "FI" }) || ""
             return (
-              <TutkintoWrapper key={i} className={customClassName}>
-                <Checkbox>
-                  <input
-                    type="checkbox"
-                    id={identifier}
-                    checked={isChecked}
-                    onChange={(e) => { handleTutkintoKieliCheckboxChange(e, editValues, fields, isInLupa, value, tutkinto) }}
-                  />
-                  <label htmlFor={identifier}></label>
-                </Checkbox>
-                <Koodi>{koulutus.koodiArvo}</Koodi>
-                <Nimi>{koulutuksenNimi}</Nimi>
-                <KieliSelect
-                  identifier={identifier}
-                  value={value}
-                  kielet={kieliListOrdered}
-                  disabled={!isChecked}
-                  editValues={editValues}
-                  fields={fields}
-                  isInLupa={isInLupa}
-                  tutkinto={tutkinto}
-                  customClass={customClassName}
-                />
-              </TutkintoWrapper>
-            )
-          })}
+              <KoulutustyyppiWrapper key={ i }>
+                <Koulutustyyppi>{ koulutustyyppiSuomeksi.nimi }</Koulutustyyppi>
+                {_.map(koulutustyyppi.koulutukset, (koulutus, i) => {
+                  const identifier = `input-tutkintokieli-2-${koulutus.koodiArvo}`
+                  const nimiObjekti = _.filter(koulutus.metadata, (m) => { return m.kieli === "FI" })
+                  const koulutuksenNimi = nimiObjekti[0].nimi
+
+                  let isInLupa = false
+                  let isAdded = false
+                  let isRemoved = false
+                  let isChanged = false
+                  let isChecked = false
+                  let valueKoodi = ""
+                  let value = ""
+
+                  tutkinnotjakielet.forEach(tutkintokieli => {
+                    if (tutkintokieli.tutkintokoodi === koulutus.koodiArvo) {
+                      isInLupa = true
+                      valueKoodi = tutkintokieli.koodi
+                    }
+                  })
+
+                  if (editValues) {
+                    editValues.forEach(val => {
+                      if (val.koodiarvo === koulutus.koodiArvo) {
+                        switch(val.type) {
+                          case MUUTOS_TYPES.ADDITION:
+                            valueKoodi = val.value
+                            isAdded = true
+                            break
+
+                          case MUUTOS_TYPES.REMOVAL:
+                            isRemoved = true
+                            break
+
+                          case MUUTOS_TYPES.CHANGE:
+                            isChanged = true
+                            break
+
+                          default:
+                            break
+                        }
+                      }
+                    })
+                  }
+
+                  let customClassName = isInLupa ? "is-in-lupa" : isAdded ? "is-added" : isRemoved ? "is-removed" : isChanged ? "is-changed" : null
+
+                  if ((isInLupa && !isRemoved)) {
+                    isChecked = true
+                    value = valueKoodi
+                  }
+
+                  if (isAdded) {
+                    isChecked = true
+                    value = valueKoodi
+                  }
+
+                  if (isInLupa && isRemoved) {
+                    value = ''
+                  }
+
+                  // Koulutus näytetään luvassa, jos se on (a) luvassa eikä sitä ole poistettu kohdassa 1 tai (b) lisätty kohdassa 1
+                  let tutkinto = _.find(maaraykset, (m) => { return m.koodi === koulutus.koodiArvo })
+                  if (!tutkinto) { tutkinto = _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.ADDITION}) }
+                  if (!tutkinto || _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.REMOVAL})) { return false }
+
+                  return (
+                    <TutkintoBlock key={i}>
+                      <TutkintoWrapper key={i} className={customClassName}>
+                        <Checkbox>
+                          <input
+                            type="checkbox"
+                            id={identifier}
+                            checked={isChecked}
+                            onChange={(e) => { handleTutkintoKieliCheckboxChange(e, editValues, fields, isInLupa, value, tutkinto) }}
+                          />
+                          <label htmlFor={identifier}></label>
+                        </Checkbox>
+                        <Koodi>{koulutus.koodiArvo}</Koodi>
+                        <Nimi>{koulutuksenNimi}</Nimi>
+                        <KieliSelect
+                          identifier={identifier}
+                          value={value}
+                          kielet={kieliListOrdered}
+                          disabled={!isChecked}
+                          editValues={editValues}
+                          fields={fields}
+                          isInLupa={isInLupa}
+                          tutkinto={tutkinto}
+                          customClass={customClassName}
+                        />
+                      </TutkintoWrapper>
+                    </TutkintoBlock>
+                  )
+                })}
+              </KoulutustyyppiWrapper>
+            )})}
         </KoulutusalaListWrapper>
         }
       </Wrapper>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoKieliList.js
@@ -18,8 +18,9 @@ import {
   KoulutustyyppiWrapper,
   TutkintoBlock
 } from './MuutospyyntoWizardComponents'
-import { handleTutkintoKieliCheckboxChange } from "../modules/koulutusUtil"
+import { handleTutkintoKieliCheckboxChange, getTutkintokieliBy } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
+import { parseLocalizedField } from "../../../../../../modules/helpers"
 
 class TutkintoKieliList extends Component {
   constructor(props) {
@@ -114,10 +115,9 @@ class TutkintoKieliList extends Component {
         {!this.state.isHidden &&
         <KoulutusalaListWrapper>
           {_.map(koulutustyypit, (koulutustyyppi, i) => {
-            const koulutustyyppiSuomeksi = _.find(koulutustyyppi.metadata, (m) => {return m.kieli === "FI" }) || ""
             return (
               <KoulutustyyppiWrapper key={ i }>
-                <Koulutustyyppi>{ koulutustyyppiSuomeksi.nimi }</Koulutustyyppi>
+                <Koulutustyyppi>{ parseLocalizedField(koulutustyyppi.metadata) }</Koulutustyyppi>
                 {_.map(koulutustyyppi.koulutukset, (koulutus, i) => {
                   const identifier = `input-tutkintokieli-2-${koulutus.koodiArvo}`
                   const nimiObjekti = _.filter(koulutus.metadata, (m) => { return m.kieli === "FI" })
@@ -178,10 +178,25 @@ class TutkintoKieliList extends Component {
                     value = ''
                   }
 
-                  // Koulutus näytetään luvassa, jos se on (a) luvassa eikä sitä ole poistettu kohdassa 1 tai (b) lisätty kohdassa 1
-                  let tutkinto = _.find(maaraykset, (m) => { return m.koodi === koulutus.koodiArvo })
-                  if (!tutkinto) { tutkinto = _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.ADDITION}) }
-                  if (!tutkinto || _.find(tutkinnotJaKoulutuksetValue, (t) => { return t.koodiarvo === koulutus.koodiArvo && t.type === MUUTOS_TYPES.REMOVAL})) { return false }
+                  // Koulutus näytetään luvassa, jos se on (a) luvassa eikä sitä ole
+                  // poistettu kohdassa 1 tai (b) lisätty kohdassa 1
+                  var tutkinto = _.find(maaraykset, (m) => {
+                    return m.koodi === koulutus.koodiArvo
+                  })
+                  if (!tutkinto) {
+                    tutkinto = _.find(tutkinnotJaKoulutuksetValue, (t) => {
+                      return (t.koodiarvo === koulutus.koodiArvo
+                        && t.type === MUUTOS_TYPES.ADDITION)
+                    })
+                  }
+                  if (!tutkinto || _.find(tutkinnotJaKoulutuksetValue, (t) => {
+                    return (t.koodiarvo === koulutus.koodiArvo
+                      && t.type === MUUTOS_TYPES.REMOVAL)})) {
+                    return false
+                  }
+
+                  tutkinto['koulutusalaKoodiArvo'] = koulutus.koulutusalaKoodiArvo
+                  tutkinto['koulutustyyppiKoodiArvo'] = koulutus.koulutustyyppiKoodiArvo
 
                   return (
                     <TutkintoBlock key={i}>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import React, { Component } from "react"
+import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 import arrow from 'static/images/koulutusala-arrow.svg'
 import {
@@ -20,6 +21,15 @@ import {
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 import { handleCheckboxChange, handleOsaamislaCheckboxChange } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
+
+const KoulutustyyppiWrapper = styled.div`
+  margin: 5px 0 20px;
+`
+
+const Koulutustyyppi = styled.div`
+  font-size: 15px;
+  font-weight: bold;
+`
 
 class TutkintoList extends Component {
   constructor(props) {
@@ -109,8 +119,8 @@ class TutkintoList extends Component {
             {_.map(koulutustyypit, (koulutustyyppi, i) => {
               const koulutustyyppiSuomeksi = _.find(koulutustyyppi.metadata, (m) => {return m.kieli === "FI" }) || ""
               return (
-                <div key={ i }>
-                  <div>{ koulutustyyppiSuomeksi.nimi }</div>
+                <KoulutustyyppiWrapper key={ i }>
+                  <Koulutustyyppi>{ koulutustyyppiSuomeksi.nimi }</Koulutustyyppi>
                   {_.map(koulutustyyppi.koulutukset, (koulutus, i) => {
                     const koodiarvo = koulutus.koodiarvo || koulutus.koodiArvo
                     const identifier = `input-${koodiarvo}`
@@ -230,7 +240,7 @@ class TutkintoList extends Component {
                 )
 
                   })}
-                </div>
+                </KoulutustyyppiWrapper>
                 )
             })}
           </KoulutusalaListWrapper>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
@@ -18,7 +18,7 @@ import {
   Nimi
 } from './MuutospyyntoWizardComponents'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
-import { handleCheckboxChange, handleOsaamislaCheckboxChange, getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
+import { handleCheckboxChange, handleOsaamislaCheckboxChange } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
 
 class TutkintoList extends Component {
@@ -147,14 +147,14 @@ class TutkintoList extends Component {
                           if (editValues) {
                             editValues.forEach(val => {
                               if (val.koodiarvo === koodiarvo) {
-                                val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : null
-                                val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : null
+                                isAdded = val.type === MUUTOS_TYPES.ADDITION ? true : null
+                                isRemoved =val.type === MUUTOS_TYPES.REMOVAL ? true : null
                               }
 
                           if (osaamisala) {
                             if (val.koodiarvo === osaamisala.koodiArvo) {
-                              val.type === MUUTOS_TYPES.ADDITION ? isOaAdded = true : null
-                              val.type === MUUTOS_TYPES.REMOVAL ? isOaRemoved = true : null
+                              isOaAdded = val.type === MUUTOS_TYPES.ADDITION ? true : null
+                              isOaRemoved = val.type === MUUTOS_TYPES.REMOVAL ? true : null
                             }
                           }
     
@@ -167,17 +167,17 @@ class TutkintoList extends Component {
                   if (editValues) {
                     editValues.forEach(val => {
                       if (val.koodiarvo === koodiarvo) {
-                        val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : null
-                        val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : null
+                        isAdded = val.type === MUUTOS_TYPES.ADDITION ? true : null
+                        isRemoved = val.type === MUUTOS_TYPES.REMOVAL ? true : null
                       }
                     })
                   }
                 }
     
                 let customClassName = ""
-                isInLupa ? customClassName = "is-in-lupa" : null
-                isAdded ? customClassName = "is-added" : null
-                isRemoved ? customClassName = "is-removed" : null
+                customClassName = isInLupa ? "is-in-lupa" : null
+                customClassName = isAdded ? "is-added" : null
+                customClassName = isRemoved ? "is-removed" : null
     
                 let isChecked = false
                 if ((isInLupa && !isRemoved) || isAdded) {
@@ -185,9 +185,9 @@ class TutkintoList extends Component {
                 }
     
                 let customClassNameForOa = ""
-                isOaInLupa ? customClassNameForOa = "is-in-lupa" : null
-                isOaAdded ? customClassNameForOa = "is-added" : null
-                isOaRemoved ? customClassNameForOa = "is-removed" : null
+                customClassNameForOa = isOaInLupa ? "is-in-lupa" : null
+                customClassNameForOa = isOaAdded ? "is-added" : null
+                customClassNameForOa = isOaRemoved ? "is-removed" : null
     
                 let isOaChecked = false
                 if ((isOaInLupa && !isOaRemoved) || isOaAdded) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
@@ -76,7 +76,7 @@ class TutkintoList extends Component {
     if (editValues) {
       _.forEach(editValues, value => {
         _.forEach(koulutukset, koulutus => {
-          if (koulutus.koodiArvo === value.koodiarvo) {
+          if (koulutus.koodiArvo === value.koodiarvo && koulutus.koodisto === value.koodisto) {
             muutokset.push(value)
           }
         })

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
@@ -18,7 +18,7 @@ import {
   Nimi
 } from './MuutospyyntoWizardComponents'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
-import { handleCheckboxChange, handleOsaamislaCheckboxChange } from "../modules/koulutusUtil"
+import { handleCheckboxChange, handleOsaamislaCheckboxChange, getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
 
 class TutkintoList extends Component {
@@ -71,10 +71,6 @@ class TutkintoList extends Component {
     let { fields, koulutukset } = this.props
     let muutokset = []
 
-    koulutukset = _.sortBy(koulutukset, k => {
-      return k.koodiArvo
-    })
-
     if (editValues) {
       _.forEach(editValues, value => {
         _.forEach(koulutukset, koulutus => {
@@ -91,6 +87,11 @@ class TutkintoList extends Component {
       alat = current.koulutusalat
     }
 
+    let koulutustyypit = []
+    _.forOwn(koulutukset, k => {
+      koulutustyypit.push(k)
+    })
+
     return (
       <Wrapper>
         <Heading onClick={this.toggleTutkintoList.bind(this)}>
@@ -102,129 +103,139 @@ class TutkintoList extends Component {
             : null
           }
         </Heading>
-        {!this.state.isHidden &&
-        <KoulutusalaListWrapper>
-          {_.map(koulutukset, (koulutus, i) => {
-            const koodiarvo = koulutus.koodiarvo || koulutus.koodiArvo
-            const identifier = `input-${koodiarvo}`
-            const { nimi, metadata } = koulutus
 
-            let nimiText = ""
-            if (!nimi && metadata) {
-              nimiText = parseLocalizedField(metadata)
-            } else {
-              nimiText = nimi
-            }
+        {!this.state.isHidden && 
+          <KoulutusalaListWrapper>
+            {_.map(koulutustyypit, (koulutustyyppi, i) => {
+              const koulutustyyppiSuomeksi = _.find(koulutustyyppi.metadata, (m) => {return m.kieli === "FI" }) || ""
+              return (
+                <div key={ i }>
+                  <div>{ koulutustyyppiSuomeksi.nimi }</div>
+                  {_.map(koulutustyyppi.koulutukset, (koulutus, i) => {
+                    const koodiarvo = koulutus.koodiarvo || koulutus.koodiArvo
+                    const identifier = `input-${koodiarvo}`
+                    const { nimi, metadata } = koulutus
+        
+                    let nimiText = ""
+                    if (!nimi && metadata) {
+                      nimiText = parseLocalizedField(metadata)
+                    } else {
+                      nimiText = nimi
+                    }
+        
+                    let isInLupa = false
+                    let isAdded = false
+                    let isRemoved = false
+        
+                    // osaamisala addons
+                    let isOaInLupa = false
+                    let isOaAdded = false
+                    let isOaRemoved = false
+                    const osaamisala = koulutus.osaamisala
+                    let identifierOa = ''
+                    if(osaamisala) {
+                      identifierOa = `input-${osaamisala.koodiArvo}`
+                    }
 
-            let isInLupa = false
-            let isAdded = false
-            let isRemoved = false
+                    if (alat) {
+                      _.forEach(alat, ({ koulutukset }) => {
+                        koulutukset.forEach(({ koodi }) => {
+                          if (koodi === koodiarvo) {
+                            isInLupa = true
+                          }
+        
+                          if (editValues) {
+                            editValues.forEach(val => {
+                              if (val.koodiarvo === koodiarvo) {
+                                val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : null
+                                val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : null
+                              }
 
-            // osaamisala addons
-            let isOaInLupa = false
-            let isOaAdded = false
-            let isOaRemoved = false
-            const osaamisala = koulutus.osaamisala
-            let identifierOa = ''
-            if(osaamisala) {
-              identifierOa = `input-${osaamisala.koodiArvo}`
-            }
-
-
-            if (alat) {
-              _.forEach(alat, ({ koulutukset }) => {
-                koulutukset.forEach(({ koodi }) => {
-                  if (koodi === koodiarvo) {
-                    isInLupa = true
-                  }
-
+                          if (osaamisala) {
+                            if (val.koodiarvo === osaamisala.koodiArvo) {
+                              val.type === MUUTOS_TYPES.ADDITION ? isOaAdded = true : null
+                              val.type === MUUTOS_TYPES.REMOVAL ? isOaRemoved = true : null
+                            }
+                          }
+    
+                        })
+                      }
+                    })
+                  })
+                } else {
+                  // Tarkastetaan myös tilanne, jossa koulutusalalla ei ollut yhtään tutkintoa luvassa, mutta alalle on lisätty tutkintoja
                   if (editValues) {
                     editValues.forEach(val => {
                       if (val.koodiarvo === koodiarvo) {
                         val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : null
                         val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : null
                       }
-
-                      if(osaamisala) {
-                        if (val.koodiarvo === osaamisala.koodiArvo) {
-                          val.type === MUUTOS_TYPES.ADDITION ? isOaAdded = true : null
-                          val.type === MUUTOS_TYPES.REMOVAL ? isOaRemoved = true : null
-                        }
-                      }
-
                     })
                   }
-                })
-              })
-            } else {
-              // Tarkastetaan myös tilanne, jossa koulutusalalla ei ollut yhtään tutkintoa luvassa, mutta alalle on lisätty tutkintoja
-              if (editValues) {
-                editValues.forEach(val => {
-                  if (val.koodiarvo === koodiarvo) {
-                    val.type === MUUTOS_TYPES.ADDITION ? isAdded = true : null
-                    val.type === MUUTOS_TYPES.REMOVAL ? isRemoved = true : null
-                  }
-                })
-              }
-            }
-
-            let customClassName = ""
-            isInLupa ? customClassName = "is-in-lupa" : null
-            isAdded ? customClassName = "is-added" : null
-            isRemoved ? customClassName = "is-removed" : null
-
-            let isChecked = false
-            if ((isInLupa && !isRemoved) || isAdded) {
-              isChecked = true
-            }
-
-            let customClassNameForOa = ""
-            isOaInLupa ? customClassNameForOa = "is-in-lupa" : null
-            isOaAdded ? customClassNameForOa = "is-added" : null
-            isOaRemoved ? customClassNameForOa = "is-removed" : null
-
-            let isOaChecked = false
-            if ((isOaInLupa && !isOaRemoved) || isOaAdded) {
-              isOaChecked = true
-            }
-
-
-            return (
-              <TutkintoBlock>
-                <TutkintoWrapper key={i} className={customClassName}>
-                  <Checkbox>
-                    <input
-                      type="checkbox"
-                      id={identifier}
-                      checked={isChecked}
-                      onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-                    />
-                    <label htmlFor={identifier}></label>
-                  </Checkbox>
-                  <Koodi>{koodiarvo}</Koodi>
-                  <Nimi>{nimiText}</Nimi>
-                </TutkintoWrapper>
-
-                { osaamisala ?
-                  <OsaamisalaWrapper key={i+999} className={customClassNameForOa}>
-                    <Checkbox>
-                      <input
-                        type="checkbox"
-                        id={identifierOa}
-                        checked={isOaChecked}
-                        onChange={(eoa) => { handleOsaamislaCheckboxChange(eoa, editValues, fields, isOaInLupa, osaamisala, koodiarvo) }}
-                      />
-                      <label htmlFor={identifierOa}></label>
-                    </Checkbox>
-                    <Osaamisala>{osaamisala.koodiArvo} {parseLocalizedField(osaamisala.metadata)} (rajoite)</Osaamisala>
-                  </OsaamisalaWrapper> : ""
                 }
+    
+                let customClassName = ""
+                isInLupa ? customClassName = "is-in-lupa" : null
+                isAdded ? customClassName = "is-added" : null
+                isRemoved ? customClassName = "is-removed" : null
+    
+                let isChecked = false
+                if ((isInLupa && !isRemoved) || isAdded) {
+                  isChecked = true
+                }
+    
+                let customClassNameForOa = ""
+                isOaInLupa ? customClassNameForOa = "is-in-lupa" : null
+                isOaAdded ? customClassNameForOa = "is-added" : null
+                isOaRemoved ? customClassNameForOa = "is-removed" : null
+    
+                let isOaChecked = false
+                if ((isOaInLupa && !isOaRemoved) || isOaAdded) {
+                  isOaChecked = true
+                }
+    
+    
+                return (
+                  <TutkintoBlock key={i}>
+                    <TutkintoWrapper key={i} className={customClassName}>
+                      <Checkbox>
+                        <input
+                          type="checkbox"
+                          id={identifier}
+                          checked={isChecked}
+                          onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
+                        />
+                        <label htmlFor={identifier}></label>
+                      </Checkbox>
+                      <Koodi>{koodiarvo}</Koodi>
+                      <Nimi>{nimiText}</Nimi>
+                    </TutkintoWrapper>
+    
+                    { osaamisala ?
+                      <OsaamisalaWrapper key={i+999} className={customClassNameForOa}>
+                        <Checkbox>
+                          <input
+                            type="checkbox"
+                            id={identifierOa}
+                            checked={isOaChecked}
+                            onChange={(eoa) => { handleOsaamislaCheckboxChange(eoa, editValues, fields, isOaInLupa, osaamisala, koodiarvo) }}
+                          />
+                          <label htmlFor={identifierOa}></label>
+                        </Checkbox>
+                        <Osaamisala>{osaamisala.koodiArvo} {parseLocalizedField(osaamisala.metadata)} (rajoite)</Osaamisala>
+                      </OsaamisalaWrapper> : ""
+                    }
+    
+                  </TutkintoBlock>
+                )
 
-              </TutkintoBlock>
-            )
-          })}
-        </KoulutusalaListWrapper>
+                  })}
+                </div>
+                )
+            })}
+          </KoulutusalaListWrapper>
         }
+
       </Wrapper>
     )
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TutkintoList.js
@@ -1,6 +1,5 @@
 import _ from 'lodash'
 import React, { Component } from "react"
-import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 import arrow from 'static/images/koulutusala-arrow.svg'
 import {
@@ -16,20 +15,13 @@ import {
   Osaamisala,
   TutkintoBlock,
   Koodi,
-  Nimi
+  Nimi,
+  Koulutustyyppi,
+  KoulutustyyppiWrapper
 } from './MuutospyyntoWizardComponents'
 import { parseLocalizedField } from "../../../../../../modules/helpers"
 import { handleCheckboxChange, handleOsaamislaCheckboxChange } from "../modules/koulutusUtil"
 import { MUUTOS_TYPES } from "../modules/uusiHakemusFormConstants"
-
-const KoulutustyyppiWrapper = styled.div`
-  margin: 5px 0 20px;
-`
-
-const Koulutustyyppi = styled.div`
-  font-size: 15px;
-  font-weight: bold;
-`
 
 class TutkintoList extends Component {
   constructor(props) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoEditWizardContainer.js
@@ -7,6 +7,7 @@ import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto, fetchMuutospyynto, updateMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
 import { fetchKoulutusalat } from "../../../../../../modules/reducers/koulutusalat"
+import { fetchKoulutustyypit } from "../../../../../../modules/reducers/koulutustyypit"
 import { fetchKoulutuksetAll, fetchKoulutuksetMuut, fetchKoulutus } from "../../../../../../modules/reducers/koulutukset"
 import { fetchPaatoskierrokset } from "../../../../../../modules/reducers/paatoskierrokset"
 import { fetchMaaraystyypit } from "../../../../../../modules/reducers/maaraystyyppi"
@@ -40,6 +41,7 @@ const mapDispatchToProps = (dispatch, props) => {
     updateMuutospyynto: (muutospyynto) => dispatch(updateMuutospyynto(muutospyynto)),
     fetchMuutospyynto: (uuid) => dispatch(fetchMuutospyynto(uuid)),
     fetchKoulutusalat: () => dispatch(fetchKoulutusalat()),
+    fetchKoulutustyypit: () => dispatch(fetchKoulutustyypit()),
     fetchKoulutuksetAll: () => dispatch(fetchKoulutuksetAll()),
     fetchKoulutuksetMuut: (koodisto) => dispatch(fetchKoulutuksetMuut(koodisto)),
     fetchKoulutus: (koodi) => dispatch(fetchKoulutus(koodi)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/containers/MuutospyyntoWizardContainer.js
@@ -7,6 +7,7 @@ import { fetchLupa } from "../../../modules/lupa"
 import { createMuutospyynto, saveMuutospyynto } from "../modules/muutospyynto"
 import { previewMuutospyynto } from "../modules/muutospyynto"
 import { fetchKoulutusalat } from "../../../../../../modules/reducers/koulutusalat"
+import { fetchKoulutustyypit } from "../../../../../../modules/reducers/koulutustyypit"
 import { fetchKoulutuksetAll, fetchKoulutuksetMuut, fetchKoulutus } from "../../../../../../modules/reducers/koulutukset"
 import { fetchPaatoskierrokset } from "../../../../../../modules/reducers/paatoskierrokset"
 import { fetchMaaraystyypit } from "../../../../../../modules/reducers/maaraystyyppi"
@@ -38,6 +39,7 @@ const mapDispatchToProps = (dispatch, props) => {
     saveMuutospyynto: (muutospyynto) => dispatch(saveMuutospyynto(muutospyynto)),
     previewMuutospyynto: (muutospyynto) => dispatch(previewMuutospyynto(muutospyynto)),
     fetchKoulutusalat: () => dispatch(fetchKoulutusalat()),
+    fetchKoulutustyypit: () => dispatch(fetchKoulutustyypit()),
     fetchKoulutuksetAll: () => dispatch(fetchKoulutuksetAll()),
     fetchKoulutuksetMuut: (koodisto) => dispatch(fetchKoulutuksetMuut(koodisto)),
     fetchKoulutus: (koodi) => dispatch(fetchKoulutus(koodi)),

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -248,6 +248,8 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
         maaraystyyppi,
         type: MUUTOS_TYPES.ADDITION,
         meta: {
+          koulutusala: currentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: currentObj.koulutustyyppiKoodiArvo,
           perusteluteksti: null,
           perusteluteksti_oppisopimus: {
             "tarpeellisuus": null,
@@ -396,6 +398,8 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
         maaraystyyppi,
         type: MUUTOS_TYPES.REMOVAL,
         meta: {
+          koulutusala: currentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: currentObj.koulutustyyppiKoodiArvo,
           perusteluteksti: null,
           perusteluteksti_oppisopimus: {
             "tarpeellisuus": null,

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -64,10 +64,12 @@ export function getTutkintoNimiByKoodiarvo(koodi) {
     let nimi = undefined
 
     _.forEach(koulutusdata, ala => {
-      _.forEach(ala.koulutukset, koulutus => {
-        if (koulutus.koodiArvo === koodi) {
-          nimi = parseLocalizedField(koulutus.metadata)
-        }
+      _.forEach(ala.koulutukset, tyyppi => {
+        _.forEach(tyyppi.koulutukset, koulutus => {
+          if (koulutus.koodiArvo === koodi) {
+            nimi = parseLocalizedField(koulutus.metadata)
+          }
+        })
       })
     })
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -674,6 +674,8 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
 
   const { checked } = event.target
 
+  console.log(currentObj)
+
   if (checked) {
     if (isInLupa) {
       // Tutkinto oli luvassa --> poistetaan se formista
@@ -693,7 +695,10 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
         kuvaus: null,
         isInLupa,
         type: MUUTOS_TYPES.ADDITION,
-        meta: { perusteluteksti: null },
+        meta: {
+          koulutusala: currentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: currentObj.koulutustyyppiKoodiArvo,
+          perusteluteksti: null },
         muutosperustelukoodiarvo: null
       })
     }
@@ -711,7 +716,10 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
         kuvaus: null,
         isInLupa,
         type: MUUTOS_TYPES.REMOVAL,
-        meta: { perusteluteksti: null },
+        meta: {
+          koulutusala: currentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: currentObj.koulutustyyppiKoodiArvo,
+          perusteluteksti: null },
         muutosperustelukoodiarvo: null
       })
     } else {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -25,6 +25,14 @@ export function getKoulutusAlat() {
   }
 }
 
+export function getKoulutusTyypit() {
+  const state = store.getState()
+
+  if (state.koulutustyypit && state.koulutustyypit.fetched) {
+    return state.koulutustyypit.data
+  }
+}
+
 export function getTutkintoNimiByKoodiarvo(koodi) {
   const state = store.getState()
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -25,11 +25,33 @@ export function getKoulutusAlat() {
   }
 }
 
+export function getKoulutusalaByKoodiarvo(koodi) {
+  const state = store.getState()
+  const { koulutusalat } = state
+
+  if (koulutusalat && koulutusalat.data) {
+    return _.find(koulutusalat.data, (a) => { return a.koodiArvo === koodi })
+  } else {
+    return undefined
+  }
+}
+
 export function getKoulutusTyypit() {
   const state = store.getState()
 
   if (state.koulutustyypit && state.koulutustyypit.fetched) {
     return state.koulutustyypit.data
+  }
+}
+
+export function getKoulutustyyppiByKoodiarvo(koodi) {
+  const state = store.getState()
+  const { koulutustyypit } = state
+
+  if (koulutustyypit && koulutustyypit.data) {
+    return _.find(koulutustyypit.data, (t) => { return t.koodiArvo === koodi })
+  } else {
+    return undefined
   }
 }
 

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -77,6 +77,28 @@ export function getTutkintoNimiByKoodiarvo(koodi) {
   }
 }
 
+export function getTutkintoByKoodiarvo(koodi) {
+  const state = store.getState()
+
+  if (state.koulutukset && state.koulutukset.koulutusdata) {
+    const { koulutusdata } = state.koulutukset
+
+    let koulutus = undefined
+
+    _.forEach(koulutusdata, ala => {
+      _.forEach(ala.koulutukset, tyyppi => {
+        _.forEach(tyyppi.koulutukset, k => {
+          if (k.koodiArvo === koodi) {
+            koulutus = k
+          }
+        })
+      })
+    })
+
+    return koulutus
+  }
+}
+
 export function getTutkintoKoodiByMaaraysId(maaraysId) {
   const state = store.getState()
 
@@ -576,6 +598,8 @@ export function handleOsaamislaCheckboxChange(event, editValue, fields, isInLupa
 
   const { checked } = event.target
 
+  const parentObj = getTutkintoByKoodiarvo(parentId)
+
   // osaamisala spesific
   let kohde = getKohdeByTunniste(KOHTEET.TUTKINNOT)
   let maaraystyyppi = getMaaraystyyppiByTunniste(MAARAYSTYYPIT.RAJOITE)
@@ -601,7 +625,11 @@ export function handleOsaamislaCheckboxChange(event, editValue, fields, isInLupa
         kohde,
         maaraystyyppi,
         type: MUUTOS_TYPES.ADDITION,
-        meta: { perusteluteksti: null },
+        meta: { 
+          perusteluteksti: null,
+          koulutusala: parentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: parentObj.koulutustyyppiKoodiArvo
+         },
         muutosperustelukoodiarvo: null
       })
     }
@@ -618,7 +646,11 @@ export function handleOsaamislaCheckboxChange(event, editValue, fields, isInLupa
         kohde,
         maaraystyyppi,
         type: MUUTOS_TYPES.REMOVAL,
-        meta: { perusteluteksti: null },
+        meta: { 
+          perusteluteksti: null,
+          koulutusala: parentObj.koulutusalaKoodiArvo,
+          koulutustyyppi: parentObj.koulutustyyppiKoodiArvo
+         },
         muutosperustelukoodiarvo: null
       })
     } else {

--- a/src/routes/Jarjestajat/Jarjestaja/modules/constants.js
+++ b/src/routes/Jarjestajat/Jarjestaja/modules/constants.js
@@ -34,6 +34,11 @@ export const TUTKINNOT_SECTIONS = {
     KULJETTAJAT: "Kuljettajakoulutukset"
 }
 
+export const KIELET_SECTIONS = {
+    OPETUSKIELET: "Opetuskielet",
+    TUTKINTOKIELET: "Tutkintokielet"
+}
+
 export const KOHTEET = {
   TUTKINNOT: 'tutkinnotjakoulutukset',
   KIELI: 'opetusjatutkintokieli',

--- a/src/routes/Jarjestajat/Jarjestaja/modules/constants.js
+++ b/src/routes/Jarjestajat/Jarjestaja/modules/constants.js
@@ -26,6 +26,14 @@ export const LUPA_SECTIONS = {
   }
 }
 
+export const TUTKINNOT_SECTIONS = {
+    TUTKINNOT: "Tutkinnot",
+    POIKKEUKSET: "Valmentavat koulutukset",
+    VALMISTAVAT: "Ammatilliseen tehtävään valmistavat koulutukset",
+    TYOVOIMAT: "Työvoimakoulutukset",
+    KULJETTAJAT: "Kuljettajakoulutukset"
+}
+
 export const KOHTEET = {
   TUTKINNOT: 'tutkinnotjakoulutukset',
   KIELI: 'opetusjatutkintokieli',

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -10,6 +10,7 @@ import muutosperustelutReducer from '../modules/reducers/muutosperustelut'
 import vankilatReducer from '../modules/reducers/vankilat'
 import ELYkeskuksetReducer from '../modules/reducers/elykeskukset'
 import koulutusalatReducer from '../modules/reducers/koulutusalat'
+import koulutustyypitReducer from '../modules/reducers/koulutustyypit'
 import koulutuksetReducer from '../modules/reducers/koulutukset'
 import paatoskierroksetReducer from '../modules/reducers/paatoskierrokset'
 import oppilaitoksenopetuskieletReducer from '../routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/oppilaitoksenopetuskielet'
@@ -33,6 +34,7 @@ const rootReducer = combineReducers({
   vankilat: vankilatReducer,
   ELYkeskukset: ELYkeskuksetReducer,
   koulutusalat: koulutusalatReducer,
+  koulutustyypit: koulutustyypitReducer,
   koulutukset: koulutuksetReducer,
   paatoskierrokset: paatoskierroksetReducer,
   oppilaitoksenopetuskielet: oppilaitoksenopetuskieletReducer,


### PR DESCRIPTION
Muutoshakemuksen muutos-, perustelu- ja yhteenvetovälilehtien tutkinto- ja tutkintokielilistauksissa tutkinnot järjestetään koulutusaloittain, koulutustyypeittäin ja aakkosittain. Koulutusalat ja -tyypit näytetään väliotsikkoina.

Osaamisalat näytetään tutkintolistoilla niihin liittyvien tutkintojen alapuolella. Jos tutkinto ei ole mukana muutospyynnössä, osaamisala näytetään siinä kohtaa, johon tutkinto kuuluisi.

Myös koulutuksille ja opetuskielille lisättiin väliotsikot selkeyden takia.