### PR TITLE
CSCOIVA-646: Kuljettajakoulutusten perustelulomakkeiden muutoksia

### DIFF
--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardComponents.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardComponents.js
@@ -3,6 +3,10 @@ import styled from 'styled-components'
 import { COLORS, MEDIA_QUERIES, TRANSITIONS } from "../../../../../../modules/styles"
 import arrowDown from 'static/images/arrow-down.svg'
 
+export const Area = styled.div`
+  margin: 15px 0;
+`
+
 export const WizardBackground = styled.div`
   background-color: rgba(255, 255, 255, 0.7);
   position: absolute;

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
@@ -1,7 +1,14 @@
+import _ from 'lodash'
+import moment from 'moment'
 import React, { Component } from 'react'
+import DatePicker from 'react-datepicker'
+import { reduxForm, FieldArray, Field } from 'redux-form'
 import styled from 'styled-components'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { meta_kuljettaja_jatko_henkilo } from "../modules/lisaperusteluUtil"
 import { getIndex } from "../modules/muutosUtil"
+import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
+import validate from '../modules/validateWizard'
 import { Checkbox } from './MuutospyyntoWizardComponents'
 
 
@@ -46,18 +53,62 @@ const InputWrapper= styled.div`
   margin-left: 20px;
 `
 
+const Radio = styled.input`
+  float: left;
+`
+const RadioWrapper = styled.div`
+  margin-left: 14px;
+  margin-top: 10px;
+`
+
+const LisaaButton = styled.button`
+  font-size: 14px;
+  margin: 5px 0 5px 20px;
+`
+
+const Opettaja = styled.div`
+  border-left: 1px solid #DFDFDF;
+  border-top: 1px solid #DFDFDF;
+  margin: 5px 0 5px 20px;
+  padding: 5px;
+`
+
 class PerusteluKuljettajaJatko extends Component {
-  constructor(props) {
-    super(props)
+
+  // Luo FieldArrayn sisään valintaruutu-Fieldin
+  // props = {'id': string, 'title': string}
+  // fieldarray = fieldarrayn nimi, string
+  // index = fieldarrayn käsiteltävä indeksi, int
+  // render = this.renderCheckbox
+  createCheckboxField(props, fieldarray, index, render) {
+    return (
+      <Field 
+        name={`${fieldarray}[${index}].${props.id}`}
+        id={`${fieldarray}_${index}_${props.id}`}
+        type="checkbox"
+        title={`${props.title}`}
+        component={render} />
+    )
+  }
+
+  renderCheckbox({input, title, id}) {
+    return (
+      <Checkbox>
+        <input
+          type="checkbox"
+          id={id}
+          {...input}
+        />
+        <label htmlFor={id}><ChkTitle>{title}</ChkTitle></label>
+      </Checkbox>
+    )
   }
 
   render() {
-    const vuosi = this.props.muutosperustelut.data[0].voimassaAlkuPvm.split("-")[0]
-
-    const { muutokset, fields, koodiarvo, perusteluteksti_kuljetus_jatko, koodisto } = this.props
+    const { muutokset, fields, koodiarvo, perusteluteksti_kuljetus_jatko } = this.props
     const { tarpeellisuus, voimassaoleva, voimassaoleva_pvm, suunnitelma } = perusteluteksti_kuljetus_jatko
-    const { osaaminen ,toimipisteet, henkilot, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_jatko
-    const { kanta_peravaunu, kanta_muut, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_jatko
+    const { osaaminen ,toimipisteet, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_jatko
+    const { kanta_peravaunu, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_jatko
 
     return (
       <PerusteluKuljettajaJatkoWrapper>
@@ -77,26 +128,44 @@ class PerusteluKuljettajaJatko extends Component {
             }}
           />
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
-          <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
-          <InputWrapper>
-            <input
-              type="text"
-              defaultValue={voimassaoleva_pvm !== null ? voimassaoleva_pvm : undefined}
-              onBlur={(e) => {
+          <RadioWrapper>
+            <Radio
+              type="radio"
+              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
+              checked={!voimassaoleva}
+              onChange={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva_pvm = e.target.value
+                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva = false
+                fields.remove(i)
+                fields.insert(i, obj)
+              }}
+            />
+            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
+          </RadioWrapper>
+          <RadioWrapper>
+            <Radio
+              type="radio"
+              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
+              checked={voimassaoleva}
+              onChange={(e) => {
+                const i = getIndex(muutokset, koodiarvo)
+                let obj = fields.get(i)
+                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva = true
+                fields.remove(i)
+                fields.insert(i, obj)
+              }}
+            />
+            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
+          </RadioWrapper>
+          <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
+          <InputWrapper>
+            <DatePicker
+              selected={voimassaoleva_pvm !== null ? moment(voimassaoleva_pvm, "DD.MM.YYYY") : undefined}
+              onChange={(date) => {
+                const i = getIndex(muutokset, koodiarvo)
+                let obj = fields.get(i)
+                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva_pvm = date.format("DD.MM.YYYY")
                 fields.remove(i)
                 fields.insert(i, obj)
               }}
@@ -253,134 +322,65 @@ class PerusteluKuljettajaJatko extends Component {
           </CheckboxWrapper>
           <h4>6. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OPETTAJA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA_TARKENNUS.FI}</Instruction>
-          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA_JATKO.FI}</Instruction>
-          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>
-          <InputWrapper>
-            <input
-              type="text"
-              defaultValue={henkilot.nimi !== null ? henkilot.nimi : undefined}
-              onBlur={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_jatko.henkilot.nimi = e.target.value
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
-          </InputWrapper>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
-          <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS.FI}</Label>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
-          <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO.FI}</Label>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
+          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA.FI}</Instruction>
+
+          {/* FieldArrayn tallennus tutkinnotjakoulutukset-rakenteen sisään tässä kohtaa tekee lomakkeesta mahdottoman hitaan.
+          Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */}
+          <FieldArray name={`perusteluteksti_kuljetus_jatko.henkilot`} component={({fields}) =>
+            <div>
+              <LisaaButton type="button" onClick={() => fields.push(meta_kuljettaja_jatko_henkilo)}>
+                {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LISAA_HENKILO.FI}
+              </LisaaButton>
+              {fields.map((opettaja, index) =>
+                <Opettaja key={index}>
+                  <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>
+                  <InputWrapper>
+                    <Field name={`${opettaja}.nimi`} type="text" component="input" />
+                  </InputWrapper>
+
+                  <CheckboxWrapper>
+                    {_.map([
+                      {'id': 'lupa', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI},
+                      {'id': 'voimassa_kuorma_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI},
+                      {'id': 'voimassa_linja_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'perusteluteksti_kuljetus_jatko.henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+
+                  <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS.FI}</Label>
+                  <CheckboxWrapper>
+                  {_.map([
+                      {'id': 'kokemus_c', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI},
+                      {'id': 'kokemus_ce', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI},
+                      {'id': 'kokemus_d', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'perusteluteksti_kuljetus_jatko.henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+
+                  <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO.FI}</Label>
+                  <CheckboxWrapper>
+                  {_.map([
+                      {'id': 'tutkinto_linja_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI},
+                      {'id': 'tutkinto_yhdistelma', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI},
+                      {'id': 'tutkinto_puutavara', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI},
+                      {'id': 'tutkinto_kuljetuspalvelu', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI},
+                      {'id': 'tutkinto_kuljetusala', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'perusteluteksti_kuljetus_jatko.henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+                </Opettaja>
+              )}
+            </div>
+          } />
           <h4>7. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.KANTA.FI}</Instruction>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_LINJA_AUTO.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_linja_auto !== null ? kanta_linja_auto : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
@@ -394,7 +394,7 @@ class PerusteluKuljettajaJatko extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_KUORMA_AUTO.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_kuorma_auto !== null ? kanta_kuorma_auto : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
@@ -408,26 +408,12 @@ class PerusteluKuljettajaJatko extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_PERAVAUNU.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_peravaunu !== null ? kanta_peravaunu : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
                 obj.meta.perusteluteksti_kuljetus_jatko.kanta_peravaunu = e.target.value
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
-          </InputWrapper>
-          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_MUUT.FI}</Instruction>
-          <InputWrapper>
-            <input
-              type="text"
-              defaultValue={kanta_muut !== null ? kanta_muut : undefined}
-              onBlur={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_jatko.kanta_muut = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
               }}
@@ -466,4 +452,9 @@ class PerusteluKuljettajaJatko extends Component {
   }
 }
 
-export default PerusteluKuljettajaJatko
+export default reduxForm({
+  form: FORM_NAME_UUSI_HAKEMUS,
+  destroyOnUnmount: false,
+  forceUnregisterOnUnmount: true,
+  validate
+})(PerusteluKuljettajaJatko)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
@@ -9,16 +9,12 @@ import { meta_kuljettaja_jatko_henkilo } from "../modules/lisaperusteluUtil"
 import { getIndex } from "../modules/muutosUtil"
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import validate from '../modules/validateWizard'
-import { Checkbox } from './MuutospyyntoWizardComponents'
-
+import { Area, Checkbox } from './MuutospyyntoWizardComponents'
 
 const PerusteluKuljettajaJatkoWrapper = styled.div`
   margin-bottom: 20px;
 `
 
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;
@@ -53,9 +49,6 @@ const InputWrapper= styled.div`
   margin-left: 20px;
 `
 
-const Radio = styled.input`
-  float: left;
-`
 const RadioWrapper = styled.div`
   margin-left: 14px;
   margin-top: 10px;
@@ -110,6 +103,8 @@ class PerusteluKuljettajaJatko extends Component {
     const { osaaminen ,toimipisteet, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_jatko
     const { kanta_peravaunu, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_jatko
 
+    const i = getIndex(muutokset, koodiarvo)
+
     return (
       <PerusteluKuljettajaJatkoWrapper>
         <h4>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.JATKO.FI}</h4>
@@ -129,33 +124,21 @@ class PerusteluKuljettajaJatko extends Component {
           />
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
           <RadioWrapper>
-            <Radio
+            <Field
+              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
+              component="input"
               type="radio"
-              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
-              checked={!voimassaoleva}
-              onChange={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva = false
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
+              value="false"
+              />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
           </RadioWrapper>
           <RadioWrapper>
-            <Radio
+            <Field
+              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
+              component="input"
               type="radio"
-              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
-              checked={voimassaoleva}
-              onChange={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_jatko.voimassaoleva = true
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
+              value="true"
+              />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
           </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
@@ -218,7 +201,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}</ChkTitle></label>
@@ -227,7 +210,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}</ChkTitle></label>
@@ -236,7 +219,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}</ChkTitle></label>
@@ -248,7 +231,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}</ChkTitle></label>
@@ -257,7 +240,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}</ChkTitle></label>
@@ -266,7 +249,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}</ChkTitle></label>
@@ -278,7 +261,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}</ChkTitle></label>
@@ -287,7 +270,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}</ChkTitle></label>
@@ -296,7 +279,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}</ChkTitle></label>
@@ -305,7 +288,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}</ChkTitle></label>
@@ -314,7 +297,7 @@ class PerusteluKuljettajaJatko extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}</ChkTitle></label>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
@@ -11,6 +11,8 @@ import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import validate from '../modules/validateWizard'
 import { Area, Checkbox } from './MuutospyyntoWizardComponents'
 
+import { COLORS } from "../../../../../../modules/styles"
+
 const PerusteluKuljettajaJatkoWrapper = styled.div`
   margin-bottom: 20px;
 `
@@ -64,6 +66,87 @@ const Opettaja = styled.div`
   border-top: 1px solid #DFDFDF;
   margin: 5px 0 5px 20px;
   padding: 5px;
+`
+
+const Radiobutton = styled.div`
+  width: 20px;
+  position: relative;
+  margin: 6px 10px;
+  
+  label {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    position: absolute;
+    top: -3px;
+    left: 0;
+    background: white;
+    border-radius: 0;
+    border: 1px solid ${COLORS.OIVA_GREEN};
+    border-radius: 16px;
+    
+    &:hover {
+      &:after {
+        border-color: ${COLORS.OIVA_GREEN};
+        opacity: 0.5;
+      }
+    }
+    
+    &:after {
+      content: '';
+      width: 9px;
+      height: 5px;
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      border: 3px solid #fcfff4;
+      border-top: none;
+      border-right: none;
+      background: transparent;
+      opacity: 0;
+      transform: rotate(-45deg);
+      border-radius: 0;
+    }
+
+  }
+  input[type=radio] {
+    visibility: hidden;
+    
+    &:checked + label {
+      background: ${COLORS.OIVA_GREEN};
+      border-radius: 16px;
+      
+      &:hover {
+        &:after {
+          background: rgba(90, 138, 112, 0.0);
+        }
+      }
+    }
+    
+    &:hover {
+      background: rgba(90, 138, 112, 0.5);
+      border-radius: 16px;
+    }
+    
+    &:checked + label:after {
+      opacity: 1;
+      background: ${COLORS.OIVA_GREEN};
+      
+      &:hover {
+        background: rgba(90, 138, 112, 0.5);
+      }
+    }
+    
+    &:checked + label:hover {
+      background: rgba(90, 138, 112, 0.5);
+      border-radius: 16px;
+      
+      &:after {
+        border-color: white;
+        opacity: 1;
+      }
+    }
+  }
 `
 
 class PerusteluKuljettajaJatko extends Component {
@@ -122,25 +205,32 @@ class PerusteluKuljettajaJatko extends Component {
               fields.insert(i, obj)
             }}
           />
+
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
           <RadioWrapper>
-            <Field
-              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
-              component="input"
-              type="radio"
-              value="false"
-              />
-            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
-          </RadioWrapper>
-          <RadioWrapper>
-            <Field
-              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
-              component="input"
-              type="radio"
-              value="true"
-              />
-            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
-          </RadioWrapper>
+            <Radiobutton>
+                <Field
+                  name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
+                  id="kuljetus_jatko_voimassa_ei"
+                  component="input"
+                  type="radio"
+                  value="false"
+                  />
+                <label htmlFor="kuljetus_jatko_voimassa_ei"><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
+              </Radiobutton>
+            </RadioWrapper>
+            <RadioWrapper>
+              <Radiobutton>
+                <Field
+                  name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_jatko.voimassaoleva`}
+                  id="kuljetus_jatko_voimassa_on"
+                  component="input"
+                  type="radio"
+                  value="true"
+                  />
+                <label htmlFor="kuljetus_jatko_voimassa_on"><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
+              </Radiobutton>
+         </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
           <InputWrapper>
             <DatePicker
@@ -154,6 +244,7 @@ class PerusteluKuljettajaJatko extends Component {
               }}
             />
           </InputWrapper>
+
           <h4>3. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.SUUNNITELMA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.SUUNNITELMA.FI}</Instruction>
           <textarea

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
@@ -9,7 +9,7 @@ import { meta_kuljettaja_jatko_henkilo } from "../modules/lisaperusteluUtil"
 import { getIndex } from "../modules/muutosUtil"
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import validate from '../modules/validateWizard'
-import { Area, Checkbox } from './MuutospyyntoWizardComponents'
+import { Area, Button, Checkbox } from './MuutospyyntoWizardComponents'
 
 import { COLORS } from "../../../../../../modules/styles"
 
@@ -54,11 +54,6 @@ const InputWrapper= styled.div`
 const RadioWrapper = styled.div`
   margin-left: 14px;
   margin-top: 10px;
-`
-
-const LisaaButton = styled.button`
-  font-size: 14px;
-  margin: 5px 0 5px 20px;
 `
 
 const Opettaja = styled.div`
@@ -402,9 +397,9 @@ class PerusteluKuljettajaJatko extends Component {
           Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */}
           <FieldArray name={`perusteluteksti_kuljetus_jatko.henkilot`} component={({fields}) =>
             <div>
-              <LisaaButton type="button" onClick={() => fields.push(meta_kuljettaja_jatko_henkilo)}>
+              <Button type="button" onClick={() => fields.push(meta_kuljettaja_jatko_henkilo)}>
                 {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LISAA_HENKILO.FI}
-              </LisaaButton>
+              </Button>
               {fields.map((opettaja, index) =>
                 <Opettaja key={index}>
                   <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 
 import "react-datepicker/dist/react-datepicker.css"
 
-import { Area, Checkbox } from './MuutospyyntoWizardComponents'
+import { Area, Button, Checkbox } from './MuutospyyntoWizardComponents'
 
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { meta_kuljettaja_perus_henkilo } from "../modules/lisaperusteluUtil"
@@ -55,11 +55,6 @@ const RadioWrapper = styled.div`
   margin-top: 10px;
 `
 
-const LisaaButton = styled.button`
-  font-size: 14px;
-  margin: 5px 0 5px 20px;
-`
-
 const Opettaja = styled.div`
   border-left: 1px solid #DFDFDF;
   border-top: 1px solid #DFDFDF;
@@ -67,7 +62,7 @@ const Opettaja = styled.div`
   padding: 5px;
 `
 
-export const Radiobutton = styled.div`
+const Radiobutton = styled.div`
   width: 20px;
   position: relative;
   margin: 6px 10px;
@@ -390,9 +385,9 @@ class PerusteluKuljettajaPerus extends Component {
           Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */}
           <FieldArray name={`perusteluteksti_kuljetus_perus.henkilot`} component={({fields}) =>
             <div>
-              <LisaaButton type="button" onClick={() => fields.push(meta_kuljettaja_perus_henkilo)}>
+              <Button type="button" onClick={() => fields.push(meta_kuljettaja_perus_henkilo)}>
                 {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LISAA_HENKILO.FI}
-              </LisaaButton>
+              </Button>
               {fields.map((opettaja, index) =>
                 <Opettaja key={index}>
                   <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -1,8 +1,15 @@
+import moment from 'moment'
 import React, { Component } from 'react'
+import DatePicker from 'react-datepicker'
 import styled from 'styled-components'
+
+import "react-datepicker/dist/react-datepicker.css"
+
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
+
 import { Checkbox } from './MuutospyyntoWizardComponents'
+
 const PerusteluKuljettajaPerusWrapper = styled.div`
   margin-bottom: 20px;
 `
@@ -113,17 +120,16 @@ class PerusteluKuljettajaPerus extends Component {
           </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
           <InputWrapper>
-            <input
-            type="date"
-            defaultValue={voimassaoleva_pvm !== null ? voimassaoleva_pvm : undefined}
-            onBlur={(e) => {
-              const i = getIndex(muutokset, koodiarvo)
-              let obj = fields.get(i)
-              obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva_pvm = e.target.value
-              fields.remove(i)
-              fields.insert(i, obj)
-            }}
-          />
+            <DatePicker
+              selected={voimassaoleva_pvm !== null ? moment(voimassaoleva_pvm, "DD.MM.YYYY") : undefined}
+              onChange={(date) => {
+                const i = getIndex(muutokset, koodiarvo)
+                let obj = fields.get(i)
+                obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva_pvm = date.format("DD.MM.YYYY")
+                fields.remove(i)
+                fields.insert(i, obj)
+              }}
+            />
           </InputWrapper>
           <h4>3. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.SUUNNITELMA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.SUUNNITELMA.FI}</Instruction>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -371,7 +371,7 @@ class PerusteluKuljettajaPerus extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_LINJA_AUTO.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_linja_auto !== null ? kanta_linja_auto : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
@@ -385,7 +385,7 @@ class PerusteluKuljettajaPerus extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_KUORMA_AUTO.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_kuorma_auto !== null ? kanta_kuorma_auto : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
@@ -399,26 +399,12 @@ class PerusteluKuljettajaPerus extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_PERAVAUNU.FI}</Instruction>
           <InputWrapper>
             <input
-              type="text"
+              type="number"
               defaultValue={kanta_peravaunu !== null ? kanta_peravaunu : undefined}
               onBlur={(e) => {
                 const i = getIndex(muutokset, koodiarvo)
                 let obj = fields.get(i)
                 obj.meta.perusteluteksti_kuljetus_perus.kanta_peravaunu = e.target.value
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
-          </InputWrapper>
-          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_MUUT.FI}</Instruction>
-          <InputWrapper>
-            <input
-              type="text"
-              defaultValue={kanta_muut !== null ? kanta_muut : undefined}
-              onBlur={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_perus.kanta_muut = e.target.value
                 fields.remove(i)
                 fields.insert(i, obj)
               }}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -42,6 +42,13 @@ const CheckboxWrapper= styled.div`
 const InputWrapper= styled.div`
   margin-left: 20px;
 `
+const Radio = styled.input`
+  float: left;
+`
+const RadioWrapper= styled.div`
+  margin-left: 14px;
+  margin-top: 10px;
+`
 
 class PerusteluKuljettajaPerus extends Component {
   constructor(props) {
@@ -55,21 +62,6 @@ class PerusteluKuljettajaPerus extends Component {
     const { tarpeellisuus, voimassaoleva, voimassaoleva_pvm, suunnitelma } = perusteluteksti_kuljetus_perus
     const { osaaminen ,toimipisteet, henkilot, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_perus
     const { kanta_peravaunu, kanta_muut, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_perus
-
-       /*
-         "nimi": null,
-        "lupa": null,
-        "voimassa_kuorma_auto": null,
-        "voimassa_linja_auto": null,
-        "luokka_C" : null,
-        "luokka_CE": null,
-        "luokka_D": null,
-        "tutkinto_linja_auto": null,
-        "tutkinto_yhdistelma": null,
-        "tutkinto_puutavara": null,
-        "tutkinto_kuljetuspalvelu": null,
-        "tutkinto_kuljetusala": null
-        */
 
     return (
       <PerusteluKuljettajaPerusWrapper>
@@ -89,17 +81,36 @@ class PerusteluKuljettajaPerus extends Component {
             }}
           />
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
-          <CheckboxWrapper>
-            <Checkbox>
-            <input
-              type="checkbox"
-              id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
+          <RadioWrapper>
+            <Radio
+              type="radio"
+              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
+              checked={!voimassaoleva}
+              onChange={(e) => {
+                const i = getIndex(muutokset, koodiarvo)
+                let obj = fields.get(i)
+                obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = false
+                fields.remove(i)
+                fields.insert(i, obj)  
+              }}
+            />
+            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
+          </RadioWrapper>
+          <RadioWrapper>
+            <Radio
+              type="radio"
+              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
               checked={voimassaoleva}
-              //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
+              onChange={(e) => {
+                const i = getIndex(muutokset, koodiarvo)
+                let obj = fields.get(i)
+                obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = true
+                fields.remove(i)
+                fields.insert(i, obj)  
+              }}
             />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
+          </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
           <InputWrapper>
             <input

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -57,14 +57,26 @@ const InputWrapper= styled.div`
 const Radio = styled.input`
   float: left;
 `
-const RadioWrapper= styled.div`
+const RadioWrapper = styled.div`
   margin-left: 14px;
   margin-top: 10px;
 `
 
+const LisaaButton = styled.button`
+  font-size: 14px;
+  margin: 5px 0 5px 20px;
+`
+
+const Opettaja = styled.div`
+  border-left: 1px solid #DFDFDF;
+  border-top: 1px solid #DFDFDF;
+  margin: 5px 0 5px 20px;
+  padding: 5px;
+`
+
 class PerusteluKuljettajaPerus extends Component {
 
-  // Luo tiettyn FieldArrayn sisään valintaruutu-Fieldin
+  // Luo FieldArrayn sisään valintaruutu-Fieldin
   // props = {'id': string, 'title': string}
   // fieldarray = fieldarrayn nimi, string
   // index = fieldarrayn käsiteltävä indeksi, int
@@ -302,17 +314,19 @@ class PerusteluKuljettajaPerus extends Component {
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA_TARKENNUS.FI}</Instruction>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA.FI}</Instruction>
 
-          {/* FieldArrayn tallennus tutkinnotjakoulutukset-rakenteen sisään tässä kohtaa tekee lomakkeesta mahdottoman hitaan. 
-          Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */} 
-          <FieldArray name={`perusteluteksti_kuljetus_perus.henkilot`} component={({fields}) => 
+          {/* FieldArrayn tallennus tutkinnotjakoulutukset-rakenteen sisään tässä kohtaa tekee lomakkeesta mahdottoman hitaan.
+          Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */}
+          <FieldArray name={`perusteluteksti_kuljetus_perus.henkilot`} component={({fields}) =>
             <div>
-              <button type="button" onClick={() => fields.push(meta_kuljettaja_perus_henkilo)}>
+              <LisaaButton type="button" onClick={() => fields.push(meta_kuljettaja_perus_henkilo)}>
                 {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LISAA_HENKILO.FI}
-              </button>
-              {fields.map((opettaja, index) => 
-                <div key={index}>
+              </LisaaButton>
+              {fields.map((opettaja, index) =>
+                <Opettaja key={index}>
                   <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>
-                  <Field name={`${opettaja}.nimi`} type="text" component="input" />
+                  <InputWrapper>
+                    <Field name={`${opettaja}.nimi`} type="text" component="input" />
+                  </InputWrapper>
 
                   <CheckboxWrapper>
                     {_.map([
@@ -347,7 +361,7 @@ class PerusteluKuljettajaPerus extends Component {
                       props, 'henkilot', index, this.renderCheckbox
                     ))}
                   </CheckboxWrapper>
-                </div>
+                </Opettaja>
               )}
             </div>
           } />

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -109,7 +109,7 @@ class PerusteluKuljettajaPerus extends Component {
     const { muutokset, fields, koodiarvo, perusteluteksti_kuljetus_perus } = this.props
     const { tarpeellisuus, voimassaoleva, voimassaoleva_pvm, suunnitelma } = perusteluteksti_kuljetus_perus
     const { toimipisteet, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_perus
-    const { kanta_peravaunu, kanta_muut, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_perus
+    const { kanta_peravaunu, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_perus
 
     return (
       <PerusteluKuljettajaPerusWrapper>
@@ -334,7 +334,7 @@ class PerusteluKuljettajaPerus extends Component {
                       {'id': 'voimassa_kuorma_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI},
                       {'id': 'voimassa_linja_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
                     ], props => this.createCheckboxField(
-                      props, 'henkilot', index, this.renderCheckbox
+                      props, 'perusteluteksti_kuljetus_perus.henkilot', index, this.renderCheckbox
                     ))}
                   </CheckboxWrapper>
 
@@ -345,7 +345,7 @@ class PerusteluKuljettajaPerus extends Component {
                       {'id': 'kokemus_ce', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI},
                       {'id': 'kokemus_d', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
                     ], props => this.createCheckboxField(
-                      props, 'henkilot', index, this.renderCheckbox
+                      props, 'perusteluteksti_kuljetus_perus.henkilot', index, this.renderCheckbox
                     ))}
                   </CheckboxWrapper>
 
@@ -358,7 +358,7 @@ class PerusteluKuljettajaPerus extends Component {
                       {'id': 'tutkinto_kuljetuspalvelu', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI},
                       {'id': 'tutkinto_kuljetusala', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
                     ], props => this.createCheckboxField(
-                      props, 'henkilot', index, this.renderCheckbox
+                      props, 'perusteluteksti_kuljetus_perus.henkilot', index, this.renderCheckbox
                     ))}
                   </CheckboxWrapper>
                 </Opettaja>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -106,7 +106,7 @@ class PerusteluKuljettajaPerus extends Component {
                 let obj = fields.get(i)
                 obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = true
                 fields.remove(i)
-                fields.insert(i, obj)  
+                fields.insert(i, obj)
               }}
             />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
@@ -114,7 +114,7 @@ class PerusteluKuljettajaPerus extends Component {
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
           <InputWrapper>
             <input
-            type="text"
+            type="date"
             defaultValue={voimassaoleva_pvm !== null ? voimassaoleva_pvm : undefined}
             onBlur={(e) => {
               const i = getIndex(muutokset, koodiarvo)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -1,12 +1,17 @@
+import _ from 'lodash'
 import moment from 'moment'
 import React, { Component } from 'react'
 import DatePicker from 'react-datepicker'
+import { reduxForm, FieldArray, Field } from 'redux-form'
 import styled from 'styled-components'
 
 import "react-datepicker/dist/react-datepicker.css"
 
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { meta_kuljettaja_perus_henkilo } from "../modules/lisaperusteluUtil"
 import { getIndex } from "../modules/muutosUtil"
+import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
+import validate from '../modules/validateWizard'
 
 import { Checkbox } from './MuutospyyntoWizardComponents'
 
@@ -58,16 +63,40 @@ const RadioWrapper= styled.div`
 `
 
 class PerusteluKuljettajaPerus extends Component {
-  constructor(props) {
-    super(props)
+
+  // Luo tiettyn FieldArrayn sisään valintaruutu-Fieldin
+  // props = {'id': string, 'title': string}
+  // fieldarray = fieldarrayn nimi, string
+  // index = fieldarrayn käsiteltävä indeksi, int
+  // render = this.renderCheckbox
+  createCheckboxField(props, fieldarray, index, render) {
+    return (
+      <Field 
+        name={`${fieldarray}[${index}].${props.id}`}
+        id={`${fieldarray}_${index}_${props.id}`}
+        type="checkbox"
+        title={`${props.title}`}
+        component={render} />
+    )
+  }
+
+  renderCheckbox({input, title, id}) {
+    return (
+      <Checkbox>
+        <input
+          type="checkbox"
+          id={id}
+          {...input}
+        />
+        <label htmlFor={id}><ChkTitle>{title}</ChkTitle></label>
+      </Checkbox>
+    )
   }
 
   render() {
-    const vuosi = this.props.muutosperustelut.data[0].voimassaAlkuPvm.split("-")[0]
-
-    const { muutokset, fields, koodiarvo, perusteluteksti_kuljetus_perus, koodisto } = this.props
+    const { muutokset, fields, koodiarvo, perusteluteksti_kuljetus_perus } = this.props
     const { tarpeellisuus, voimassaoleva, voimassaoleva_pvm, suunnitelma } = perusteluteksti_kuljetus_perus
-    const { osaaminen ,toimipisteet, henkilot, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_perus
+    const { toimipisteet, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_perus
     const { kanta_peravaunu, kanta_muut, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_perus
 
     return (
@@ -98,7 +127,7 @@ class PerusteluKuljettajaPerus extends Component {
                 let obj = fields.get(i)
                 obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = false
                 fields.remove(i)
-                fields.insert(i, obj)  
+                fields.insert(i, obj)
               }}
             />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
@@ -268,130 +297,61 @@ class PerusteluKuljettajaPerus extends Component {
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}</ChkTitle></label>
             </Checkbox>
           </CheckboxWrapper>
+
           <h4>5. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OPETTAJA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA_TARKENNUS.FI}</Instruction>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.OPETTAJA.FI}</Instruction>
-          <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>
-          <InputWrapper>
-            <input
-              type="text"
-              defaultValue={henkilot.nimi !== null ? henkilot.nimi : undefined}
-              onBlur={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_perus.henkilot.nimi = e.target.value
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
-          </InputWrapper>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
-          <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS.FI}</Label>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
-          <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO.FI}</Label>
-          <CheckboxWrapper>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}</ChkTitle></label>
-            </Checkbox>
-            <Checkbox>
-              <input
-                type="checkbox"
-                id={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
-                checked={voimassaoleva}
-                //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
-              />
-              <label htmlFor={'opettaja-'+MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}</ChkTitle></label>
-            </Checkbox>
-          </CheckboxWrapper>
+
+          {/* FieldArrayn tallennus tutkinnotjakoulutukset-rakenteen sisään tässä kohtaa tekee lomakkeesta mahdottoman hitaan. 
+          Tallenna erilliseen muuttujaan ja siirrä oikeaan paikkaan vasta tallennuksen yhteydessä. */} 
+          <FieldArray name={`perusteluteksti_kuljetus_perus.henkilot`} component={({fields}) => 
+            <div>
+              <button type="button" onClick={() => fields.push(meta_kuljettaja_perus_henkilo)}>
+                {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LISAA_HENKILO.FI}
+              </button>
+              {fields.map((opettaja, index) => 
+                <div key={index}>
+                  <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.HENKILO.FI}</Instruction>
+                  <Field name={`${opettaja}.nimi`} type="text" component="input" />
+
+                  <CheckboxWrapper>
+                    {_.map([
+                      {'id': 'lupa', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI},
+                      {'id': 'voimassa_kuorma_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI},
+                      {'id': 'voimassa_linja_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+
+                  <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS.FI}</Label>
+                  <CheckboxWrapper>
+                  {_.map([
+                      {'id': 'kokemus_c', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI},
+                      {'id': 'kokemus_ce', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI},
+                      {'id': 'kokemus_d', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+
+                  <Label>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO.FI}</Label>
+                  <CheckboxWrapper>
+                  {_.map([
+                      {'id': 'tutkinto_linja_auto', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI},
+                      {'id': 'tutkinto_yhdistelma', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI},
+                      {'id': 'tutkinto_puutavara', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI},
+                      {'id': 'tutkinto_kuljetuspalvelu', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI},
+                      {'id': 'tutkinto_kuljetusala', 'title': MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
+                    ], props => this.createCheckboxField(
+                      props, 'henkilot', index, this.renderCheckbox
+                    ))}
+                  </CheckboxWrapper>
+                </div>
+              )}
+            </div>
+          } />
+
           <h4>6. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.KANTA.FI}</Instruction>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA_LINJA_AUTO.FI}</Instruction>
@@ -483,4 +443,9 @@ class PerusteluKuljettajaPerus extends Component {
   }
 }
 
-export default PerusteluKuljettajaPerus
+export default reduxForm({
+  form: FORM_NAME_UUSI_HAKEMUS,
+  destroyOnUnmount: false,
+  forceUnregisterOnUnmount: true,
+  validate
+})(PerusteluKuljettajaPerus)

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -15,6 +15,8 @@ import { getIndex } from "../modules/muutosUtil"
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import validate from '../modules/validateWizard'
 
+import { COLORS } from "../../../../../../modules/styles"
+
 const Label = styled.label`
   flex: 1;
   font-size: 14px;
@@ -63,6 +65,87 @@ const Opettaja = styled.div`
   border-top: 1px solid #DFDFDF;
   margin: 5px 0 5px 20px;
   padding: 5px;
+`
+
+export const Radiobutton = styled.div`
+  width: 20px;
+  position: relative;
+  margin: 6px 10px;
+  
+  label {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    position: absolute;
+    top: -3px;
+    left: 0;
+    background: white;
+    border-radius: 0;
+    border: 1px solid ${COLORS.OIVA_GREEN};
+    border-radius: 16px;
+    
+    &:hover {
+      &:after {
+        border-color: ${COLORS.OIVA_GREEN};
+        opacity: 0.5;
+      }
+    }
+    
+    &:after {
+      content: '';
+      width: 9px;
+      height: 5px;
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      border: 3px solid #fcfff4;
+      border-top: none;
+      border-right: none;
+      background: transparent;
+      opacity: 0;
+      transform: rotate(-45deg);
+      border-radius: 0;
+    }
+
+  }
+  input[type=radio] {
+    visibility: hidden;
+    
+    &:checked + label {
+      background: ${COLORS.OIVA_GREEN};
+      border-radius: 16px;
+      
+      &:hover {
+        &:after {
+          background: rgba(90, 138, 112, 0.0);
+        }
+      }
+    }
+    
+    &:hover {
+      background: rgba(90, 138, 112, 0.5);
+      border-radius: 16px;
+    }
+    
+    &:checked + label:after {
+      opacity: 1;
+      background: ${COLORS.OIVA_GREEN};
+      
+      &:hover {
+        background: rgba(90, 138, 112, 0.5);
+      }
+    }
+    
+    &:checked + label:hover {
+      background: rgba(90, 138, 112, 0.5);
+      border-radius: 16px;
+      
+      &:after {
+        border-color: white;
+        opacity: 1;
+      }
+    }
+  }
 `
 
 class PerusteluKuljettajaPerus extends Component {
@@ -124,22 +207,28 @@ class PerusteluKuljettajaPerus extends Component {
 
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
           <RadioWrapper>
-            <Field
-              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
-              component="input"
-              type="radio"
-              value="false"
-              />
-            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
+            <Radiobutton>
+              <Field
+                name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
+                id="kuljetus_perus_voimassa_ei"
+                component="input"
+                type="radio"
+                value="false"
+                />
+              <label htmlFor="kuljetus_perus_voimassa_ei"><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
+            </Radiobutton>
           </RadioWrapper>
           <RadioWrapper>
-            <Field
-              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
-              component="input"
-              type="radio"
-              value="true"
-              />
-            <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
+            <Radiobutton>
+              <Field
+                name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
+                id="kuljetus_perus_voimassa_on"
+                component="input"
+                type="radio"
+                value="true"
+                />
+              <label htmlFor="kuljetus_perus_voimassa_on"><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
+            </Radiobutton>
           </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
           <InputWrapper>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -7,21 +7,14 @@ import styled from 'styled-components'
 
 import "react-datepicker/dist/react-datepicker.css"
 
+import { Area, Checkbox } from './MuutospyyntoWizardComponents'
+
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { meta_kuljettaja_perus_henkilo } from "../modules/lisaperusteluUtil"
 import { getIndex } from "../modules/muutosUtil"
 import { FORM_NAME_UUSI_HAKEMUS } from "../modules/uusiHakemusFormConstants"
 import validate from '../modules/validateWizard'
 
-import { Checkbox } from './MuutospyyntoWizardComponents'
-
-const PerusteluKuljettajaPerusWrapper = styled.div`
-  margin-bottom: 20px;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;
@@ -54,9 +47,7 @@ const CheckboxWrapper= styled.div`
 const InputWrapper= styled.div`
   margin-left: 20px;
 `
-const Radio = styled.input`
-  float: left;
-`
+
 const RadioWrapper = styled.div`
   margin-left: 14px;
   margin-top: 10px;
@@ -111,8 +102,10 @@ class PerusteluKuljettajaPerus extends Component {
     const { toimipisteet, kanta_linja_auto, kanta_kuorma_auto } = perusteluteksti_kuljetus_perus
     const { kanta_peravaunu, valineet_asetus, valineet_muut } = perusteluteksti_kuljetus_perus
 
+    const i = getIndex(muutokset, koodiarvo)
+
     return (
-      <PerusteluKuljettajaPerusWrapper>
+      <div>
         <h4>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.PERUS.FI}</h4>
         <Area>
           <h4>1. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.TARPEELLISUUS.FI}</h4>
@@ -128,35 +121,24 @@ class PerusteluKuljettajaPerus extends Component {
               fields.insert(i, obj)
             }}
           />
+
           <h4>2. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA.FI}</h4>
           <RadioWrapper>
-            <Radio
+            <Field
+              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
+              component="input"
               type="radio"
-              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
-              checked={!voimassaoleva}
-              onChange={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = false
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
+              value="false"
+              />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.EI.FI}</ChkTitle></label>
           </RadioWrapper>
           <RadioWrapper>
-            <Radio
+            <Field
+              name={`tutkinnotjakoulutukset[${i}].meta.perusteluteksti_kuljetus_perus.voimassaoleva`}
+              component="input"
               type="radio"
-              name={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}
-              checked={voimassaoleva}
-              onChange={(e) => {
-                const i = getIndex(muutokset, koodiarvo)
-                let obj = fields.get(i)
-                obj.meta.perusteluteksti_kuljetus_perus.voimassaoleva = true
-                fields.remove(i)
-                fields.insert(i, obj)
-              }}
-            />
+              value="true"
+              />
             <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.VOIMASSAOLEVA_PVM.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.YLEINEN.KYLLA.FI}</ChkTitle></label>
           </RadioWrapper>
           <Tarkenne>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.VOIMASSAOLEVA.FI}</Tarkenne>
@@ -172,6 +154,7 @@ class PerusteluKuljettajaPerus extends Component {
               }}
             />
           </InputWrapper>
+
           <h4>3. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.SUUNNITELMA.FI}</h4>
           <Instruction>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OHJEET.SUUNNITELMA.FI}</Instruction>
           <textarea
@@ -207,7 +190,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LUPA.FI}</ChkTitle></label>
@@ -216,7 +199,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KUORMA_AUTO.FI}</ChkTitle></label>
@@ -225,7 +208,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.LINJA_AUTO.FI}</ChkTitle></label>
@@ -237,7 +220,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_C.FI}</ChkTitle></label>
@@ -246,7 +229,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_CE.FI}</ChkTitle></label>
@@ -255,7 +238,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KOKEMUS_D.FI}</ChkTitle></label>
@@ -267,7 +250,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_LINJA_AUTO.FI}</ChkTitle></label>
@@ -276,7 +259,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_YHDISTELMA.FI}</ChkTitle></label>
@@ -285,7 +268,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_PUUTAVARA.FI}</ChkTitle></label>
@@ -294,7 +277,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSPALVELU.FI}</ChkTitle></label>
@@ -303,7 +286,7 @@ class PerusteluKuljettajaPerus extends Component {
               <input
                 type="checkbox"
                 id={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}
-                checked={voimassaoleva}
+                checked={false}
                 //onChange={(e) => { handleCheckboxChange(e, editValues, fields, isInLupa, koulutus) }}
               />
               <label htmlFor={MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}><ChkTitle>{MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.TUTKINTO_KULJETUSALA.FI}</ChkTitle></label>
@@ -438,7 +421,7 @@ class PerusteluKuljettajaPerus extends Component {
             }}
           />
         </Area>
-      </PerusteluKuljettajaPerusWrapper>
+      </div>
     )
   }
 }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimus.js
@@ -2,14 +2,12 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluOppisopimusWrapper = styled.div`
   margin-bottom: 20px;
 `
 
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluOppisopimusYhteenveto.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluWrapper = styled.div`
   display: flex;
@@ -23,10 +24,6 @@ const Label = styled.div`
 const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
 `
 
 class PerusteluOppisopimusYhteenveto extends Component {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluSimple.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluSimple.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 
 import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluWrapper = styled.div`
   display: flex;
@@ -24,10 +25,6 @@ const Label = styled.div`
 const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
 `
 
 class PerusteluSimple extends Component {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoima.js
@@ -5,14 +5,12 @@ import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
 import Select from '../../../../../../modules/Select'
 import { handleELYkeskusSelectChange } from "../modules/ELYkeskusUtil"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluTyovoimaWrapper = styled.div`
   margin-bottom: 20px;
 `
 
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluTyovoimaYhteenveto.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import _ from 'lodash'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluWrapper = styled.div`
   display: flex;
@@ -24,10 +25,6 @@ const Label = styled.div`
 const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
 `
 
 class PerusteluTyovoimaYhteenveto extends Component {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativa.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativa.js
@@ -2,14 +2,12 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluVaativaWrapper = styled.div`
   margin-bottom: 20px;
 `
 
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVaativaYhteenveto.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluWrapper = styled.div`
   display: flex;
@@ -23,10 +24,6 @@ const Label = styled.div`
 const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
 `
 
 class PerusteluVaativaYhteenveto extends Component {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankila.js
@@ -5,14 +5,12 @@ import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
 import { getIndex } from "../modules/muutosUtil"
 import Select from '../../../../../../modules/Select'
 import { handleVankilaSelectChange } from "../modules/vankilaUtil"
+import { Area } from './MuutospyyntoWizardComponents'
 
 const PerusteluVankilaWrapper = styled.div`
   margin-bottom: 20px;
 `
 
-const Area = styled.div`
-  margin: 15px 0;
-`
 const Label = styled.label`
   flex: 1;
   font-size: 14px;

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluVankilaYhteenveto.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import _ from 'lodash'
 import { COLORS } from "../../../../../../modules/styles"
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
+import { Area } from './MuutospyyntoWizardComponents'
 
 // import { getMuutosperusteluByKoodiArvo } from "../modules/muutosperusteluUtil"
 
@@ -27,11 +28,6 @@ const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
 `
-
-const Area = styled.div`
-  margin: 15px 0;
-`
-
 class PerusteluVankilaYhteenveto extends Component {
   componentWillMount() {
     const { muutosperustelut } = this.props

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TaloudellisetYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/TaloudellisetYhteenveto.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
 
+import { Area } from './MuutospyyntoWizardComponents'
 import { MUUTOS_WIZARD_TEKSTIT } from "../modules/constants"
-
 import { COLORS } from "../../../../../../modules/styles"
 
 const MuutosListWrapper = styled.div`
@@ -37,10 +37,6 @@ const Label = styled.div`
 const Content = styled.div`
   margin-left: 20px;
   font-style: italic;
-`
-
-const Area = styled.div`
-  margin: 15px 0;
 `
 
 class TaloudellisetYhteenveto extends Component {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/constants.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/constants.js
@@ -276,6 +276,10 @@ export const MUUTOS_WIZARD_TEKSTIT = {
         FI:"Kyllä",
         SV:"Ja"
       },
+      EI: {
+        FI:"Ei",
+        SV:"Nej"
+      },
       TARPEELLISUUS: {
         FI: "Tehtävän tarpeellisuus",
         SV: "På svenska"

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/koulutusUtil.js
@@ -252,7 +252,6 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
   const { checked } = event.target
 
   if (!kohde) {
-    console.log('koulutusUtil.handleCheckboxChange kohdetta ei löytynyt', currentObj)
     if (koodistoUri === KOODISTOT.KOULUTUS) {
       kohde = getKohdeByTunniste(KOHTEET.TUTKINNOT)
     } else if (koodistoUri === KOODISTOT.OPPILAITOKSENOPETUSKIELI) {
@@ -263,7 +262,6 @@ export function handleCheckboxChange(event, editValue, fields, isInLupa, current
   }
 
   if (!maaraystyyppi) {
-    console.log('koulutusUtil.handleCheckboxChange määräystyyppiä ei löytynyt', currentObj)
     if (koodistoUri === KOODISTOT.KOULUTUS) {
       maaraystyyppi = getMaaraystyyppiByTunniste(MAARAYSTYYPIT.OIKEUS)
     } else if (koodistoUri === KOODISTOT.OPPILAITOKSENOPETUSKIELI) {
@@ -427,8 +425,6 @@ export function handleTutkintoKieliCheckboxChange(event, editValue, fields, isIn
   }
 
   const { checked } = event.target
-
-  console.log(currentObj)
 
   if (checked) {
     if (isInLupa) {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
@@ -1,6 +1,6 @@
 export const meta_kuljettaja_jatko = {
   "tarpeellisuus": null,
-  "voimassaoleva": null,
+  "voimassaoleva": "false",
   "voimassaoleva_pvm": null,
   "suunnitelma": null,
   "osaaminen":null,
@@ -29,7 +29,7 @@ export const meta_kuljettaja_jatko = {
 
 export const meta_kuljettaja_perus = {
   "tarpeellisuus": null,
-  "voimassaoleva": null,
+  "voimassaoleva": "false",
   "voimassaoleva_pvm": null,
   "suunnitelma": null,
   "toimipisteet": {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
@@ -18,20 +18,7 @@ export const meta_kuljettaja_jatko = {
     "tutkinto_kuljetuspalvelu": null,
     "tutkinto_kuljetusala": null
   },
-  "henkilot": {
-    "nimi":null,
-    "lupa": null,
-    "voimassa_kuorma_auto": null,
-    "voimassa_linja_auto": null,
-    "luokka_C" : null,
-    "luokka_CE": null,
-    "luokka_D": null,
-    "tutkinto_linja_auto": null,
-    "tutkinto_yhdistelma": null,
-    "tutkinto_puutavara": null,
-    "tutkinto_kuljetuspalvelu": null,
-    "tutkinto_kuljetusala": null
-  },
+  "henkilot": [],
   "kanta_linja_auto": null,
   "kanta_kuorma_auto": null,
   "kanta_peravaunu": null,
@@ -59,26 +46,28 @@ export const meta_kuljettaja_perus = {
     "tutkinto_kuljetuspalvelu": null,
     "tutkinto_kuljetusala": null
   },
-  "henkilot": {
-    "nimi":null,
-    "lupa": null,
-    "voimassa_kuorma_auto": null,
-    "voimassa_linja_auto": null,
-    "luokka_C" : null,
-    "luokka_CE": null,
-    "luokka_D": null,
-    "tutkinto_linja_auto": null,
-    "tutkinto_yhdistelma": null,
-    "tutkinto_puutavara": null,
-    "tutkinto_kuljetuspalvelu": null,
-    "tutkinto_kuljetusala": null
-  },
+  "henkilot": [],
   "kanta_linja_auto": null,
   "kanta_kuorma_auto": null,
   "kanta_peravaunu": null,
   "kanta_muut": null,
   "valineet_asetus": null,
   "valineet_muut": null
+}
+
+export const meta_kuljettaja_perus_henkilo = {
+  "nimi": null,
+  "lupa": null,
+  "voimassa_kuorma_auto": null,
+  "voimassa_linja_auto": null,
+  "luokka_C" : null,
+  "luokka_CE": null,
+  "luokka_D": null,
+  "tutkinto_linja_auto": null,
+  "tutkinto_yhdistelma": null,
+  "tutkinto_puutavara": null,
+  "tutkinto_kuljetuspalvelu": null,
+  "tutkinto_kuljetusala": null
 }
 
 export const meta_oppisopimus = {

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/lisaperusteluUtil.js
@@ -70,6 +70,21 @@ export const meta_kuljettaja_perus_henkilo = {
   "tutkinto_kuljetusala": null
 }
 
+export const meta_kuljettaja_jatko_henkilo = {
+  "nimi": null,
+  "lupa": null,
+  "voimassa_kuorma_auto": null,
+  "voimassa_linja_auto": null,
+  "luokka_C" : null,
+  "luokka_CE": null,
+  "luokka_D": null,
+  "tutkinto_linja_auto": null,
+  "tutkinto_yhdistelma": null,
+  "tutkinto_puutavara": null,
+  "tutkinto_kuljetuspalvelu": null,
+  "tutkinto_kuljetusala": null
+}
+
 export const meta_oppisopimus = {
   "tarpeellisuus": null,
   "henkilosto": null,


### PR DESCRIPTION
Muutokset molempiin kuljettajakoulutusten perustelulomakkeisiin:
- Ammattipätevyys:
-- Checkbox muutettu kahdeksi radiovalinnaksi
-- Päivämääräkentän komponentti vaihdettu tekstikentästä react-datepickeriin
- Opettajien pätevyys:
-- Mahdollisuus lisätä useita opettajia
-- Tehdyt valinnat tallennetaan muutospyyntöön
- Ajoneuvokanta:
-- Kenttien tyyppi muutettu tekstistä numeroksi
-- Muut, mitä -kenttä poistettu