### PR TITLE
Cscoiva 713: Yhteenvedon liitteet

### DIFF
--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liite.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liite.js
@@ -53,7 +53,9 @@ class Liite extends Component {
     return (
       <div>
         <LiiteTopArea>
-          {HAKEMUS_OTSIKOT.LIITE_OHJE.FI}
+          { this.props.helpText && this.props.helpText }
+          { this.props.helpText && " " }
+          { HAKEMUS_OTSIKOT.LIITE_OHJE.FI }
         </LiiteTopArea>
         <FileInput>
           <div><FaPlus /> {HAKEMUS_OTSIKOT.LISAA_LIITE.FI}...</div>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
@@ -167,24 +167,24 @@ class Liiteet extends Component {
     let liitteetObj = {};
     let index = 0;
 
-    const addAttachment = () => {
-      if (this.state.fileName) {
+    const addAttachment = (e, name) => {
+      if (this.state.fileName || name) {
         this.setState( {nameMissing: false })
         this.closeNameModal();
-        let items = [...this.state.liite];
-        items.nimi = this.state.fileName;
-        this.setState( {liite: items });
+        liite = this.state.liite;
+        name ? liite.nimi = name : liite.nimi = this.state.fileName;
+        this.setState( {liite: liite });
         if (koodiarvo) {
-          this.state.liitteetObj.liitteet.push(this.state.liite);
+          this.state.liitteetObj.liitteet.push(liite);
           fields.remove(index);
           fields.insert(index, this.state.liitteetObj);
         } else {
           if (!fields.liitteet) {
             fields.liitteet = [];
           }
-          fields.liitteet.push(this.state.liite);
+          fields.liitteet.push(liite);
         }
-        this.setState({fileAdded: this.state.liite.nimi })
+        this.setState({fileAdded: liite.nimi })
       } else this.setState( {nameMissing: true })
     }
 
@@ -349,7 +349,7 @@ class Liiteet extends Component {
                 <LiiteListItem>
                   {liite.new ? <FaFile /> : <FaRegFile /> }
                   <input 
-                    onBlur={(e) => {(e) => setAttachmentName(e, liite.tiedostoId, liite.uuid)}} 
+                    onBlur={(e) => {setAttachmentName(e, liite.tiedostoId, liite.uuid)}} 
                     defaultValue={liite.nimi} 
                     onKeyPress={e => {
                       if (e.key === 'Enter') {
@@ -437,16 +437,24 @@ class Liiteet extends Component {
                 e.target.value = '';
                 e.target.value = val;
               }}
-              onBlur={(e) => {
+              onBlur={e => {
                   this.setState( {fileName: e.target.value} )
-                }}
+              }}
+              onKeyPress={e => {
+                if (e.key === 'Enter') {
+                  this.setState({
+                    fileName: e.target.value
+                  });
+                  addAttachment(e, e.target.value)
+                }
+              }}
               />
             <Error>
               { this.state.nameMissing && HAKEMUS_VIESTI.TIEDOSTO_NIMI_ERROR.FI }
             </Error>
           </Content>
           <div>
-            <ModalButton primary onClick={addAttachment}>{HAKEMUS_VIESTI.OK.FI}</ModalButton>
+            <ModalButton primary onClick={(e) => addAttachment(e)}>{HAKEMUS_VIESTI.OK.FI}</ModalButton>
             <ModalButton
               onClick={this.closeNameModal}>
               {HAKEMUS_VIESTI.PERUUTA.FI}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
@@ -343,7 +343,7 @@ class Liiteet extends Component {
 
       if (obj && obj.liitteet)
         return  obj.liitteet.map( liite => {
-          if ( (!paikka || liite.paikka === paikka) && !liite.removed) {
+          if ( (!paikka || liite.paikka.startsWith(paikka)) && !liite.removed) {
             return (
               <div key={ liite.tiedostoId ? liite.tiedostoId : liite.uuid }>
                 <LiiteListItem>
@@ -393,7 +393,7 @@ class Liiteet extends Component {
       if (obj && obj.liitteet) {
 
         obj.liitteet.map( liite => {
-          if ( (!paikka || liite.paikka === paikka) && !liite.removed) {
+          if ( (!paikka || liite.paikka.startsWith(paikka)) && !liite.removed) {
             return true
           }
         })
@@ -409,7 +409,7 @@ class Liiteet extends Component {
         }
         { this.props.listHidden && <br /> }
         { !this.props.showListOnly && 
-          <Liite setAttachment={setAttachment} setAttachmentName={setAttachmentName} /> 
+          <Liite setAttachment={setAttachment} setAttachmentName={setAttachmentName} helpText={this.props.helpText} /> 
         }
         { this.state.fileError && 
           <Error>{HAKEMUS_VIRHE.LIITE.FI}</Error>

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Liitteet.js
@@ -68,6 +68,11 @@ const Checkbox = styled.div`
     }
   }
 `
+const AttachmentWrapper = styled.div`
+  &.intend {
+    margin-left: 30px;
+  }
+`
 const LiiteListItem = styled.div`
   font-size: 14px;
   display: flex;
@@ -376,9 +381,30 @@ class Liiteet extends Component {
       return null;
     }
 
+    const showHeader = () => {
+      let obj = undefined;
+      if (koodiarvo) {
+        const i = getIndex(muutokset, koodiarvo);
+        obj = fields.get(i);
+      }
+      else 
+        obj = fields;
+
+      if (obj && obj.liitteet) {
+
+        obj.liitteet.map( liite => {
+          if ( (!paikka || liite.paikka === paikka) && !liite.removed) {
+            return true
+          }
+        })
+        return false
+      }
+      else return false
+    }
+
     return (
-      <div>
-        { !this.props.listHidden && 
+      <AttachmentWrapper className={this.props.isIntend ? 'intend' :''}>
+        { ((!this.props.listHidden && !this.props.showListOnly) || (this.props.showListOnly && showHeader())) &&
           <h4>{this.props.header ? this.props.header: HAKEMUS_OTSIKOT.LIITE_HEADER.FI }</h4>
         }
         { this.props.listHidden && <br /> }
@@ -427,7 +453,7 @@ class Liiteet extends Component {
             </ModalButton>
           </div>
         </Modal>
-      </div>
+      </AttachmentWrapper>
     )
 
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosList.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosList.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import Muutos from './Muutos'
 import MuutosYhteenveto from './MuutosYhteenveto'
 import { COMPONENT_TYPES } from "../modules/uusiHakemusFormConstants"
+import Liitteet from './Liitteet'
 
 const MuutosListWrapper = styled.div`
 `
@@ -55,6 +56,9 @@ class MuutosList extends Component {
             </MuutosWrapper>
           )
         })}
+        {fields && fields.length > 0 && 
+            <Liitteet {...this.props} fields={fields} paikka="kuljettaja" showListOnly={true} isIntend={true}/>
+          }
       </MuutosListWrapper>
     )
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutosListTutkinnot.js
@@ -9,6 +9,7 @@ import { TUTKINNOT_SECTIONS, KIELET_SECTIONS } from "../../../modules/constants"
 import { FIELD_ARRAY_NAMES} from "../modules/uusiHakemusFormConstants"
 import { getKoulutusalaByKoodiarvo, getKoulutustyyppiByKoodiarvo, getTutkintoNimiByKoodiarvo } from "../modules/koulutusUtil"
 import { parseLocalizedField } from "../../../../../../modules/helpers"
+import Liitteet from './Liitteet'
 
 const MuutosListWrapper = styled.div`
 `
@@ -279,6 +280,7 @@ class MuutosListTutkinnot extends Component {
                     sisaltaa_merkityksen={sisaltaa_merkityksen}
                     componentType={componentType}
                   />
+                   {/* <Liitteet {...this.props} fields={muutos} paikka="kuljettaja" isListOnly={true}/>     */}
                 </MuutosWrapper>
               )
             })}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardPerustelut.js
@@ -56,7 +56,7 @@ let MuutospyyntoWizardPerustelut = props => {
             />
 
             {tutkinnotjakoulutuksetValue && tutkinnotjakoulutuksetValue.length > 0 && 
-              <Liitteet fields={formValues} paikka="tutkinnot" /> 
+              <Liitteet fields={formValues} paikka="tutkinnot" isIntend={true}/> 
             }
 
             <FieldArray

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
@@ -149,7 +149,7 @@ class MuutospyyntoWizardYhteenveto extends Component {
           />
 
           {tutkinnotjakoulutuksetValue && tutkinnotjakoulutuksetValue.length > 0 && 
-            <Liitteet {...this.props} fields={formValues} paikka="tutkinnot" />
+            <Liitteet {...this.props} fields={formValues} paikka="tutkinnot" showListOnly={true} isIntend={true}/>
           }
 
           <FieldArray
@@ -200,6 +200,10 @@ class MuutospyyntoWizardYhteenveto extends Component {
             heading="Taloudelliset edellytykset"
             component={TaloudellisetYhteenveto}
           />
+
+          {taloudellisetValue && taloudellisetValue.length > 0 && 
+            <Liitteet {...this.props} fields={formValues.taloudelliset[0]} paikka="taloudelliset" showListOnly={true} isIntend={true}/>
+          }
 
           <WizardBottom>
             <Container maxWidth="1085px" padding="15px">

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
@@ -105,8 +105,6 @@ class MuutospyyntoWizardYhteenveto extends Component {
       jarjestaja = lupa.data.jarjestaja
     }
 
-    const { meta } = formValues
-
     return (
       <div>
         <h2>{MUUTOS_WIZARD_TEKSTIT.YHTEENVETO.HEADING.FI}</h2>
@@ -125,13 +123,9 @@ class MuutospyyntoWizardYhteenveto extends Component {
 
           <FieldArray
             name={FIELD_ARRAY_NAMES.HAKIJAN_TIEDOT}
-            meta={meta}
+            formValues={formValues}
             component={this.renderHakijanTiedot}
           />
-
-          <Separator />
-
-          <Liitteet {...this.props} fields={formValues} paikka="yleiset" header={ HAKEMUS_OTSIKOT.LIITE_YLEISET_HEADER.FI }/>
 
           <Separator />
 
@@ -147,10 +141,6 @@ class MuutospyyntoWizardYhteenveto extends Component {
             component={MuutosListTutkinnot}
             componentType={COMPONENT_TYPES.MUUTOS_YHTEENVETO}
           />
-
-          {tutkinnotjakoulutuksetValue && tutkinnotjakoulutuksetValue.length > 0 && 
-            <Liitteet {...this.props} fields={formValues} paikka="tutkinnot" showListOnly={true} isIntend={true}/>
-          }
 
           <FieldArray
             name={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
@@ -205,6 +195,10 @@ class MuutospyyntoWizardYhteenveto extends Component {
             <Liitteet {...this.props} fields={formValues.taloudelliset[0]} paikka="taloudelliset" showListOnly={true} isIntend={true}/>
           }
 
+          <Separator />
+
+          <Liitteet {...this.props} fields={this.props.formValues} paikka="yleiset" header={HAKEMUS_OTSIKOT.LIITE_YLEISET_HEADER.FI}/>
+
           <WizardBottom>
             <Container maxWidth="1085px" padding="15px">
               <Button onClick={previousPage} className="previous button-left">Edellinen</Button>
@@ -258,6 +252,7 @@ class MuutospyyntoWizardYhteenveto extends Component {
   }
 
   renderHakijanTiedot() {
+    const { meta } = this.props.formValues
     return (
       <div>
         <Field
@@ -284,6 +279,17 @@ class MuutospyyntoWizardYhteenveto extends Component {
           label="Yhteyshenkilön sähköposti"
           component={this.renderField}
         />
+       <Field
+          name="hakija.haettupvm"
+          type="text"
+          label="Muutoksien voimaantulo"
+          component={this.renderDatePicker}
+        />
+        <Field
+          name="hakija.saate"
+          label="Saate"
+          component={this.renderTextarea}
+        />
         <Field
           name="hakija.hyvaksyjat"
           type="text"
@@ -296,17 +302,7 @@ class MuutospyyntoWizardYhteenveto extends Component {
           label="Hyväksyjän/allekirjoittajan nimike"
           component={this.renderField}
         />
-        <Field
-          name="hakija.haettupvm"
-          type="text"
-          label="Muutoksien voimaantulo"
-          component={this.renderDatePicker}
-        />
-        <Field
-          name="hakija.saate"
-          label="Saate"
-          component={this.renderTextarea}
-        />
+        <Liitteet {...this.props} fields={this.props.formValues} paikka="yhteenveto" header={ " " } helpText={HAKEMUS_OTSIKOT.LIITE_YHTEENVETO_OHJE.FI}/>
       </div>
     )
   }

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardYhteenveto.js
@@ -148,6 +148,10 @@ class MuutospyyntoWizardYhteenveto extends Component {
             componentType={COMPONENT_TYPES.MUUTOS_YHTEENVETO}
           />
 
+          {tutkinnotjakoulutuksetValue && tutkinnotjakoulutuksetValue.length > 0 && 
+            <Liitteet {...this.props} fields={formValues} paikka="tutkinnot" />
+          }
+
           <FieldArray
             name={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}
             nimi={FIELD_ARRAY_NAMES.OPETUS_JA_TUTKINTOKIELET}

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaJatko.js
@@ -526,9 +526,6 @@ class PerusteluKuljettajaJatko extends Component {
               fields.insert(i, obj)
             }}
           />
-          <CheckboxWrapper>
-            <Liitteet {...this.props} />
-          </CheckboxWrapper>
         </Area>
       </PerusteluKuljettajaJatkoWrapper>
     )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/PerusteluKuljettajaPerus.js
@@ -379,7 +379,7 @@ class PerusteluKuljettajaPerus extends Component {
             </Checkbox>
           </CheckboxWrapper>
           <CheckboxWrapper>
-            <Liitteet {...this.props} paikka="kuljetta-perus1"/>
+            <Liitteet {...this.props} paikka="kuljettaja-perus1"/>
           </CheckboxWrapper>
 
           <h4>5. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.OPETTAJA.FI}</h4>
@@ -438,7 +438,7 @@ class PerusteluKuljettajaPerus extends Component {
             </div>
           } />
           <CheckboxWrapper>
-            <Liitteet {...this.props} paikka="kuljetta-perus2" />
+            <Liitteet {...this.props} paikka="kuljettaja-perus2" />
           </CheckboxWrapper>
 
           <h4>6. {MUUTOS_WIZARD_TEKSTIT.MUUTOS_PERUSTELULOMAKKEET.KULJETTAJAKOULUTUS.KANTA.FI}</h4>
@@ -512,9 +512,6 @@ class PerusteluKuljettajaPerus extends Component {
               fields.insert(i, obj)
             }}
           />
-          <CheckboxWrapper>
-            <Liitteet {...this.props} />
-          </CheckboxWrapper>
         </Area>
       </div>
     )

--- a/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/uusiHakemusFormConstants.js
+++ b/src/routes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/modules/uusiHakemusFormConstants.js
@@ -181,7 +181,11 @@ export const HAKEMUS_OTSIKOT = {
     SV: 'På Svenska'
   },
   LIITE_OHJE: {
-    FI: 'Liitteen koko saa olla korkeintaan 25 MB ja tyypiltään pdf, word, excel, jpeg tai gif. Muista merkitä salassa pidettävät liitteet.',
+    FI: 'Liitteen koko saa olla korkeintaan 25 MB ja tyypiltään pdf, word, excel, jpeg tai gif. Muistakaa merkitä salassa pidettävät liitteet.',
+    SV: 'På Svenska'
+  },
+  LIITE_YHTEENVETO_OHJE: {
+    FI: 'Liittäkää asiakirja tai asiakirjat, joista ilmenee hakemuksen hyväksyntä tai hyväksyjän päätösvalta (esim. hyväksyjän allekirjoitusoikeus ja päättävän elimen kokouksen pöytäkirjanote).',
     SV: 'På Svenska'
   },
   LISAA_LIITE: {


### PR DESCRIPTION
Tehty:
Liitteiden sijanteihin muutoksia yhteenvedossa
Korjattu liitteiden nimeämistä
Tuki enter-näppäimen painamiselle nimeämisen dialogille
Sisennykset
Korjattu nimeäminen

EI TEHTY:
Yhteenvedossa eivät vielä tehty kuljettakoulusten liitteet (yhteenveto tekemättä)
Taloudelliset edellytykset odottaa liitteiden metatieto-tukea backendiltä