### PR TITLE
CSCKIJA-163 fix

### DIFF
--- a/src/services/muutoshakemus/utils/tutkinnotUtils.js
+++ b/src/services/muutoshakemus/utils/tutkinnotUtils.js
@@ -232,8 +232,7 @@ export const getCategoriesForPerustelut = (
                         : ""),
                     labelStyles: {
                       addition: isAdded,
-                      removal: isRemoved,
-                      custom: Object.assign({}, isInLupaBool ? isInLupa : {})
+                      removal: isRemoved
                     },
                     styleClasses: ["flex"],
                     statusTextStyleClasses: isAddition


### PR DESCRIPTION
Tutkinto title was wrongly being set to a bold font weight. This fix removes the custom style and affects Perustelut and Yhteenveto views in MuutospyyntoWizard.