### PR TITLE
Cscoiva 507 2

### DIFF
--- a/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
+++ b/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
@@ -70,7 +70,6 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
     ).isChecked;
 
     setConstraintFlags({
-      ...constraintFlags,
       isVaativaTukiVisible: isVaativatInLupa || isVaativatInChanges,
       isSisaoppilaitosVisible: isSisaoppilaitosInLupa || isSisaoppilaitosInChanges
     })
@@ -204,7 +203,7 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
         props.stateObjects.muut.muutdata
       );
 
-      const constraintFlagChanges = {...constraintFlags};
+      const changedConstraintFlags = {};
       if (sisaoppilaitosState) {
         const isSisaoppilaitosCheckedByDefault = sisaoppilaitosState
           ? sisaoppilaitosState.categories[0].categories[0].components[0]
@@ -245,8 +244,8 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
 
         const shouldSisaoppilaitosBeVisible = isCheckedByDefault || isCheckedByChange;
 
-        constraintFlagChanges.isSisaoppilaitosVisible = shouldSisaoppilaitosBeVisible;
-        constraintFlagChanges.isSisaoppilaitosValueRequired = isCheckedByChange;
+        changedConstraintFlags.isSisaoppilaitosVisible = shouldSisaoppilaitosBeVisible;
+        changedConstraintFlags.isSisaoppilaitosValueRequired = isCheckedByChange;
       }
 
       const vaativatukiState = R.find(
@@ -299,11 +298,11 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
 
         const shouldVaativatBeVisible = isVaativatukiCheckedByDefault || isCheckedByChange;
 
-        constraintFlagChanges.isVaativaTukiVisible = shouldVaativatBeVisible;
-        constraintFlagChanges.isVaativaTukiValueRequired = isCheckedByChange;
+        changedConstraintFlags.isVaativaTukiVisible = shouldVaativatBeVisible;
+        changedConstraintFlags.isVaativaTukiValueRequired = isCheckedByChange;
       }
 
-      setConstraintFlags({...constraintFlagChanges});
+      setConstraintFlags({...changedConstraintFlags});
 
       // Let's set koodiarvot so that they can be used when saving the muutoshakemus.
       setKoodiarvot(prevState => {

--- a/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
+++ b/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
@@ -43,6 +43,7 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
   const [initialValueSisaoppilaitos] = useState(0);
   const [categories, setCategories] = useState([]);
 
+  // This effect is run depending on existing 'lupa', from props alone (run only on first render)
   useEffect(() => {
     const relevantChangesOfSection5 = R.concat(
       (props.changesOfSection5 || {})["02"] || [],
@@ -190,6 +191,7 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
     props.sectionId
   ]);
 
+  // This effect is run depending on changes in section 5
   useEffect(() => {
     if (props.muut && props.stateObjects.muut.muutdata) {
       let sisaoppilaitosKoodiarvo = null;

--- a/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
+++ b/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
@@ -20,18 +20,20 @@ const isInLupa = (areaCode, items) => {
   }, items);
 };
 
+const defaultConstraintFlags = {
+  isVaativaTukiVisible: false,
+  isSisaoppilaitosVisible: false,
+  isVaativaTukiValueRequired: false,
+  isSisaoppilaitosValueRequired: false
+};
+
 const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
   const { onChangesRemove, onChangesUpdate, onStateUpdate } = props;
   const { kohteet } = props.lupa;
   const { opiskelijavuodet } = kohteet[4];
   const { muutCombined } = kohteet[5];
 
-  const [constraintFlags, setConstraintFlags] = useState({
-    isVaativaTukiVisible: false,
-    isSisaoppilaitosVisible: false,
-    isVaativaTukiValueRequired: false,
-    isSisaoppilaitosValueRequired: false
-  });
+  const [constraintFlags, setConstraintFlags] = useState(defaultConstraintFlags);
   const [applyFor, setApplyFor] = useState(0);
   const [applyForVaativa, setApplyForVaativa] = useState(0);
   const [applyForSisaoppilaitos, setApplyForSisaoppilaitos] = useState(0);
@@ -205,7 +207,8 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
         props.stateObjects.muut.muutdata
       );
 
-      const changedConstraintFlags = {};
+      const newConstraintFlags = {};
+
       if (sisaoppilaitosState) {
         const isSisaoppilaitosCheckedByDefault = sisaoppilaitosState
           ? sisaoppilaitosState.categories[0].categories[0].components[0]
@@ -246,8 +249,8 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
 
         const shouldSisaoppilaitosBeVisible = isCheckedByDefault || isCheckedByChange;
 
-        changedConstraintFlags.isSisaoppilaitosVisible = shouldSisaoppilaitosBeVisible;
-        changedConstraintFlags.isSisaoppilaitosValueRequired = isCheckedByChange;
+        newConstraintFlags.isSisaoppilaitosVisible = shouldSisaoppilaitosBeVisible;
+        newConstraintFlags.isSisaoppilaitosValueRequired = isCheckedByChange;
       }
 
       const vaativatukiState = R.find(
@@ -300,11 +303,16 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
 
         const shouldVaativatBeVisible = isVaativatukiCheckedByDefault || isCheckedByChange;
 
-        changedConstraintFlags.isVaativaTukiVisible = shouldVaativatBeVisible;
-        changedConstraintFlags.isVaativaTukiValueRequired = isCheckedByChange;
+        newConstraintFlags.isVaativaTukiVisible = shouldVaativatBeVisible;
+        newConstraintFlags.isVaativaTukiValueRequired = isCheckedByChange;
       }
 
-      setConstraintFlags({...changedConstraintFlags});
+      setConstraintFlags(previousConstraintFlags => {
+        return {
+          ...previousConstraintFlags,
+          ...newConstraintFlags
+        }
+      });
 
       // Let's set koodiarvot so that they can be used when saving the muutoshakemus.
       setKoodiarvot(prevState => {

--- a/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
+++ b/src/scenes/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
@@ -71,7 +71,9 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(props => {
 
     setConstraintFlags({
       isVaativaTukiVisible: isVaativatInLupa || isVaativatInChanges,
-      isSisaoppilaitosVisible: isSisaoppilaitosInLupa || isSisaoppilaitosInChanges
+      isSisaoppilaitosVisible: isSisaoppilaitosInLupa || isSisaoppilaitosInChanges,
+      isVaativaTukiValueRequired: !isVaativatInLupa && isVaativatInChanges,
+      isSisaoppilaitosValueRequired: !isSisaoppilaitosInLupa && isSisaoppilaitosInChanges
     })
   }, [muutCombined, props.lupa, props.changesOfSection5]);
 


### PR DESCRIPTION
Fixes the react-hooks/exhaustive-deps linter warning for MuutospyyntoWizardOpiskelijavuodet. No longer having the unhygienic use of spread operator for useState variable.

* Making sure that we set full constraintFlags on first render's useEffect.
* Properly using previous state for constraintFlags in useEffect based on section 5 changes.
