### PR TITLE
CSCOIVA-1460 changed h2 to h1 in frontpage

### DIFF
--- a/src/scenes/Home/index.js
+++ b/src/scenes/Home/index.js
@@ -14,7 +14,7 @@ const Home = () => {
       <Helmet htmlAttributes={{ lang: locale }}>
         <title>Oiva | {formatMessage(common.frontpage)}</title>
       </Helmet>
-      <Typography component="h2" variant="h4" className="p-4">
+      <Typography component="h1" variant="h4" className="p-4">
         {formatMessage(homepage.header)}
       </Typography>
       <Card className="p-4">


### PR DESCRIPTION
Only h2 in typography is changed to h1 for accessibility reasons