### PR TITLE
CSCKUJA-483: Opetuskielivalikkoon kaikki kielet

### DIFF
--- a/src/basedata.js
+++ b/src/basedata.js
@@ -22,7 +22,11 @@ import localforage from "localforage";
 import { backendRoutes } from "stores/utils/backendRoutes";
 import { useParams } from "react-router-dom";
 import { initializeMaakunta } from "helpers/maakunnat";
-import { filterOPHKielet, initializeKieli } from "helpers/kielet";
+import {
+  filterEnsisijaisetOpetuskieletOPH,
+  filterToissijaisetOpetuskieletOPH,
+  initializeKieli
+} from "helpers/kielet";
 import { sortLanguages } from "utils/kieliUtil";
 import { initializeKoulutusala } from "helpers/koulutusalat";
 import { initializeKoulutustyyppi } from "helpers/koulutustyypit";
@@ -236,12 +240,15 @@ const fetchBaseData = async (keys, locale, ytunnus) => {
           )
         )
       : undefined,
-    kieletOPH: raw.kielet
+    ensisijaisetOpetuskieletOPH: raw.kielet
       ? await localforage.setItem(
-          "kieletOPH",
-          map(kieli => {
-            return initializeKieli(kieli);
-          }, filterOPHKielet(raw.kieletOPH))
+          "ensisijaisetOpetuskieletOPH",
+          filterEnsisijaisetOpetuskieletOPH(
+            map(kieli => {
+              return initializeKieli(kieli);
+            }, raw.kieletOPH),
+            localeUpper
+          )
         )
       : undefined,
     kohteet: raw.kohteet
@@ -439,6 +446,17 @@ const fetchBaseData = async (keys, locale, ytunnus) => {
           initializePOMuutEhdot(
             raw.poMuutEhdot,
             prop("maaraykset", raw.lupa) || []
+          )
+        )
+      : undefined,
+    toissijaisetOpetuskieletOPH: raw.kieletOPH
+      ? await localforage.setItem(
+          "toissijaisetOpetuskieletOPH",
+          filterToissijaisetOpetuskieletOPH(
+            map(kieli => {
+              return initializeKieli(kieli);
+            }, raw.kieletOPH),
+            localeUpper
           )
         )
       : undefined,

--- a/src/helpers/kielet/index.js
+++ b/src/helpers/kielet/index.js
@@ -13,16 +13,40 @@ import {
   filter,
   propEq,
   path,
-  find
+  find,
+  concat,
+  uniq,
+  sortBy
 } from "ramda";
 import localforage from "localforage";
 
-const kaytetytOPHKielet = ["FI", "SV", "SE", "RI", "VK", "EN", "FR", "DE", "RU"]
+const ensisijaisetOPHKielet = ["FI", "SV", "SE", "RI", "VK"];
 
-export const filterOPHKielet = (kielet) => {
-  return map(kielikoodi =>
-    find(propEq("koodiArvo", kielikoodi), kielet), kaytetytOPHKielet);
-}
+const toissijaisetOPHKielet = ["EN", "FR", "DE", "RU"];
+
+export const filterEnsisijaisetOpetuskieletOPH = (kielet, localeUpper) => {
+  return uniq(
+    concat(
+      map(
+        kielikoodi => find(propEq("koodiarvo", kielikoodi), kielet),
+        ensisijaisetOPHKielet
+      ),
+      sortBy(path(["metadata", localeUpper, "nimi"]), kielet)
+    )
+  );
+};
+
+export const filterToissijaisetOpetuskieletOPH = (kielet, localeUpper) => {
+  return uniq(
+    concat(
+      map(
+        kielikoodi => find(propEq("koodiarvo", kielikoodi), kielet),
+        toissijaisetOPHKielet
+      ),
+      sortBy(path(["metadata", localeUpper, "nimi"]), kielet)
+    )
+  );
+};
 
 export const initializeKieli = ({
   koodiArvo: koodiarvo,

--- a/src/helpers/opetuskielet/index.js
+++ b/src/helpers/opetuskielet/index.js
@@ -12,7 +12,8 @@ import {
   filter,
   compose,
   includes,
-  flatten, pathEq
+  flatten,
+  pathEq
 } from "ramda";
 import localforage from "localforage";
 import { getLisatiedotFromStorage } from "../lisatiedot";
@@ -55,8 +56,13 @@ export const initializeOpetuskielet = (opetuskieletData, maaraykset = []) => {
     : [];
 };
 
-export const defineBackendChangeObjects = async (changeObjects = [], maaraystyypit, locale, kohteet) => {
-  const opetuskielet = await getkieletOPHFromStorage();
+export const defineBackendChangeObjects = async (
+  changeObjects = [],
+  maaraystyypit,
+  locale,
+  kohteet
+) => {
+  const opetuskielet = await getEnsisijaisetOpetuskieletOPHFromStorage();
   const lisatiedot = await getLisatiedotFromStorage();
 
   const lisatiedotObj = find(
@@ -64,7 +70,10 @@ export const defineBackendChangeObjects = async (changeObjects = [], maaraystyyp
     lisatiedot || []
   );
 
-  const opetuskieletChangeObjs = filter(compose(startsWith("opetuskielet.opetuskieli"), prop("anchor")), changeObjects);
+  const opetuskieletChangeObjs = filter(
+    compose(startsWith("opetuskielet.opetuskieli"), prop("anchor")),
+    changeObjects
+  );
 
   /** Lisätietokentän käsittely */
   const lisatiedotChangeObj = find(
@@ -72,41 +81,53 @@ export const defineBackendChangeObjects = async (changeObjects = [], maaraystyyp
     changeObjects
   );
 
-  const lisatiedotBeChangeObj = lisatiedotChangeObj ?
-    {
-      kohde: find(propEq("tunniste", "opetusjatutkintokieli"), kohteet),
-      koodiarvo: lisatiedotObj.koodiarvo,
-      koodisto: lisatiedotObj.koodisto.koodistoUri,
-      kuvaus: path(["metadata", locale, "kuvaus"], lisatiedotChangeObj),
-      maaraystyyppi: find(propEq("tunniste", "OIKEUS"), maaraystyypit),
-      meta: {
-        arvo: path(["properties", "value"], lisatiedotChangeObj),
-        changeObjects: [lisatiedotChangeObj]
-      },
-      tila: "LISAYS" } : [];
+  const lisatiedotBeChangeObj = lisatiedotChangeObj
+    ? {
+        kohde: find(propEq("tunniste", "opetusjatutkintokieli"), kohteet),
+        koodiarvo: lisatiedotObj.koodiarvo,
+        koodisto: lisatiedotObj.koodisto.koodistoUri,
+        kuvaus: path(["metadata", locale, "kuvaus"], lisatiedotChangeObj),
+        maaraystyyppi: find(propEq("tunniste", "OIKEUS"), maaraystyypit),
+        meta: {
+          arvo: path(["properties", "value"], lisatiedotChangeObj),
+          changeObjects: [lisatiedotChangeObj]
+        },
+        tila: "LISAYS"
+      }
+    : [];
 
   /** Opetuskielten käsittely */
   const opetuskieliBeChangeObjects = map(opetuskieli => {
-    const changeObj = find(cObj => find(kieli => kieli.value === opetuskieli.koodiarvo, cObj.properties.value), opetuskieletChangeObjs);
+    const changeObj = find(
+      cObj =>
+        find(
+          kieli => kieli.value === opetuskieli.koodiarvo,
+          cObj.properties.value
+        ),
+      opetuskieletChangeObjs
+    );
 
-    return changeObj ? {
-      generatedId: `opetuskielet-${Math.random()}`,
-      kohde: find(propEq("tunniste", "opetusjatutkintokieli"), kohteet),
-      koodiarvo: opetuskieli.koodiarvo,
-      koodisto: opetuskieli.koodisto.koodistoUri,
-      kuvaus: path(["metadata", locale, "kuvaus"], changeObj),
-      maaraystyyppi: find(propEq("tunniste", "OIKEUS"), maaraystyypit),
-      meta: {
-        changeObjects: [changeObj]
-      },
-      tila: "LISAYS"
-    } : null
+    return changeObj
+      ? {
+          generatedId: `opetuskielet-${Math.random()}`,
+          kohde: find(propEq("tunniste", "opetusjatutkintokieli"), kohteet),
+          koodiarvo: opetuskieli.koodiarvo,
+          koodisto: opetuskieli.koodisto.koodistoUri,
+          kuvaus: path(["metadata", locale, "kuvaus"], changeObj),
+          maaraystyyppi: find(propEq("tunniste", "OIKEUS"), maaraystyypit),
+          meta: {
+            changeObjects: [changeObj]
+          },
+          tila: "LISAYS"
+        }
+      : null;
   }, opetuskielet);
 
-  return flatten([opetuskieliBeChangeObjects, lisatiedotBeChangeObj]).filter(Boolean);
+  return flatten([opetuskieliBeChangeObjects, lisatiedotBeChangeObj]).filter(
+    Boolean
+  );
+};
 
-}
-
-export function getkieletOPHFromStorage() {
-  return localforage.getItem("kieletOPH");
+export function getEnsisijaisetOpetuskieletOPHFromStorage() {
+  return localforage.getItem("ensisijaisetOpetuskieletOPH");
 }

--- a/src/scenes/EsiJaPerusopetus/AsiaDialogContainer.js
+++ b/src/scenes/EsiJaPerusopetus/AsiaDialogContainer.js
@@ -29,8 +29,8 @@ import { useEsiJaPerusopetus } from "../../stores/esiJaPerusopetus";
  * @param {Object} props.intl - Object of react-intl library.
  */
 const AsiaDialogContainer = ({
+  ensisijaisetOpetuskieletOPH,
   kielet,
-  kieletOPH,
   kohteet,
   koulutukset,
   koulutusalat,
@@ -48,6 +48,7 @@ const AsiaDialogContainer = ({
   organisaatio,
   poErityisetKoulutustehtavat,
   poMuutEhdot,
+  toissijaisetOpetuskieletOPH,
   tutkinnot,
   viimeisinLupa
 }) => {
@@ -167,9 +168,9 @@ const AsiaDialogContainer = ({
 
   return muutospyynto && state.changeObjects ? (
     <UusiAsiaDialog
+      ensisijaisetOpetuskieletOPH={ensisijaisetOpetuskieletOPH}
       history={history}
       kielet={kielet}
-      kieletOPH={kieletOPH}
       kohteet={kohteet}
       koulutukset={koulutukset}
       koulutusalat={koulutusalat}
@@ -190,6 +191,7 @@ const AsiaDialogContainer = ({
       opetustehtavakoodisto={opetustehtavakoodisto}
       opetustehtavat={opetustehtavat}
       organisation={organisaatio}
+      toissijaisetOpetuskieletOPH={toissijaisetOpetuskieletOPH}
       tutkinnot={tutkinnot}
     />
   ) : (

--- a/src/scenes/EsiJaPerusopetus/UusiAsiaDialog.js
+++ b/src/scenes/EsiJaPerusopetus/UusiAsiaDialog.js
@@ -63,8 +63,8 @@ const FormDialog = withStyles(() => ({
 });
 
 const defaultProps = {
+  ensisijaisetOpetuskieletOPH: [],
   kielet: [],
-  kieletOPH: [],
   kohteet: [],
   koulutukset: {
     muut: {},
@@ -87,11 +87,12 @@ const defaultProps = {
   organisation: {},
   poErityisetKoulutustehtavat: [],
   poMuutEhdot: [],
+  toissijaisetOpetuskieletOPH: [],
   tutkinnot: []
 };
 
 const UusiAsiaDialog = ({
-  kieletOPH = defaultProps.kieletOPH,
+  ensisijaisetOpetuskieletOPH = defaultProps.ensisijaisetOpetuskieletOPH,
   kohteet = defaultProps.kohteet,
   kunnat = defaultProps.kunnat,
   lisatiedot = defaultProps.lisatiedot,
@@ -107,7 +108,8 @@ const UusiAsiaDialog = ({
   opetustehtavakoodisto = defaultProps.opetustehtavakoodisto,
   organisation = defaultProps.organisation,
   poErityisetKoulutustehtavat = defaultProps.poErityisetKoulutustehtavat,
-  poMuutEhdot = defaultProps.poMuutEhdot
+  poMuutEhdot = defaultProps.poMuutEhdot,
+  toissijaisetOpetuskieletOPH = defaultProps.toissijaisetOpetuskieletOPH
 }) => {
   const [state, actions] = useEsiJaPerusopetus();
 
@@ -411,8 +413,9 @@ const UusiAsiaDialog = ({
                   render={props => (
                     <Opetuskieli
                       changeObjects={state.changeObjects.opetuskielet}
-                      kieletOPH={kieletOPH}
+                      ensisijaisetOpetuskieletOPH={ensisijaisetOpetuskieletOPH}
                       lisatiedot={lisatiedot}
+                      toissijaisetOpetuskieletOPH={toissijaisetOpetuskieletOPH}
                       {...props}
                     />
                   )}

--- a/src/scenes/EsiJaPerusopetus/UusiAsiaDialogContainer.js
+++ b/src/scenes/EsiJaPerusopetus/UusiAsiaDialogContainer.js
@@ -12,8 +12,8 @@ import { isEmpty } from "ramda";
  * @param {Object} props.intl - Object of react-intl library.
  */
 const UusiAsiaDialogContainer = ({
+  ensisijaisetOpetuskieletOPH,
   kielet,
-  kieletOPH,
   kohteet,
   koulutukset,
   koulutusalat,
@@ -31,6 +31,7 @@ const UusiAsiaDialogContainer = ({
   organisaatio,
   poErityisetKoulutustehtavat,
   poMuutEhdot,
+  toissijaisetOpetuskieletOPH,
   tutkinnot,
   viimeisinLupa
 }) => {
@@ -64,7 +65,7 @@ const UusiAsiaDialogContainer = ({
     <UusiAsiaDialog
       history={history}
       kielet={kielet}
-      kieletOPH={kieletOPH}
+      ensisijaisetOpetuskieletOPH={ensisijaisetOpetuskieletOPH}
       kohteet={kohteet}
       koulutukset={koulutukset}
       koulutusalat={koulutusalat}
@@ -85,6 +86,7 @@ const UusiAsiaDialogContainer = ({
       organisation={organisaatio}
       poErityisetKoulutustehtavat={poErityisetKoulutustehtavat}
       poMuutEhdot={poMuutEhdot}
+      toissijaisetOpetuskieletOPH={toissijaisetOpetuskieletOPH}
       tutkinnot={tutkinnot}
     />
   );

--- a/src/scenes/EsiJaPerusopetus/lomake/3-Opetuskieli.js
+++ b/src/scenes/EsiJaPerusopetus/lomake/3-Opetuskieli.js
@@ -7,11 +7,12 @@ import common from "../../../i18n/definitions/common";
 
 const Opetuskieli = ({
   changeObjects,
-  kieletOPH,
+  ensisijaisetOpetuskieletOPH,
   lisatiedot,
   onChangesRemove,
   onChangesUpdate,
-  sectionId
+  sectionId,
+  toissijaisetOpetuskieletOPH
 }) => {
   const intl = useIntl();
 
@@ -38,8 +39,9 @@ const Opetuskieli = ({
         anchor={sectionId}
         changeObjects={changeObjects}
         data={{
-          kieletOPH,
-          lisatiedot
+          ensisijaisetOpetuskieletOPH,
+          lisatiedot,
+          toissijaisetOpetuskieletOPH
         }}
         onChangesUpdate={onChangesUpdate}
         path={["esiJaPerusopetus", "opetuskielet"]}
@@ -55,7 +57,8 @@ Opetuskieli.defaultProps = {
 Opetuskieli.propTypes = {
   changeObjects: PropTypes.array,
   onChangesUpdate: PropTypes.func,
-  kieletOPH: PropTypes.array
+  ensisijaisetOpetuskieletOPH: PropTypes.array,
+  toissijaisetOpetuskieletOPH: PropTypes.array
 };
 
 export default Opetuskieli;

--- a/src/services/lomakkeet/esi-ja-perusopetus/3-opetuskielet.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/3-opetuskielet.js
@@ -1,7 +1,48 @@
-import { map, toUpper, take, takeLast, find, pathEq } from "ramda";
-import {__} from "i18n-for-browser";
+import {
+  map,
+  toUpper,
+  find,
+  pathEq,
+  not,
+  includes,
+  prop,
+  path,
+  filter,
+  uniq,
+  concat
+} from "ramda";
+import { __ } from "i18n-for-browser";
 
-export function opetuskielet(data, isReadOnly, locale) {
+export function getOpetuskieletOPHLomake(
+  data,
+  isReadOnly,
+  locale,
+  changeObjects
+) {
+  // TODO: Huomioidaan myöhemmin myös lupaan kuuluvat kielet
+  const valitutEnsisijaisetKoodiarvot = map(
+    prop("value"),
+    path([0, "properties", "value"], changeObjects) || []
+  );
+
+  const valitutToissijaisetKoodiarvot = map(
+    prop("value"),
+    path([1, "properties", "value"], changeObjects) || []
+  );
+
+  const valitutKoodiarvot = uniq(
+    concat(valitutEnsisijaisetKoodiarvot, valitutToissijaisetKoodiarvot)
+  );
+
+  const valittavanaOlevatEnsisisijaisetOpetuskielet = filter(
+    kieli => not(includes(kieli.koodiarvo, valitutKoodiarvot)),
+    data.ensisijaisetOpetuskieletOPH
+  );
+
+  const valittavanaOlevatToissisijaisetOpetuskielet = filter(
+    kieli => not(includes(kieli.koodiarvo, valitutKoodiarvot)),
+    data.toissijaisetOpetuskieletOPH
+  );
 
   const lisatiedotObj = find(
     pathEq(["koodisto", "koodistoUri"], "lisatietoja"),
@@ -24,11 +65,8 @@ export function opetuskielet(data, isReadOnly, locale) {
                 label: kieli.metadata[localeUpper].nimi,
                 value: kieli.koodiarvo
               };
-            }, take(5, data.kieletOPH)),
-            callback: (payload, values) => {
-              console.log(values.value[0]);
-            },
-            title: __("common.valitseYksiTaiUseampi"),
+            }, valittavanaOlevatEnsisisijaisetOpetuskielet),
+            title: __("common.valitseYksiTaiUseampi")
           }
         }
       ]
@@ -47,11 +85,8 @@ export function opetuskielet(data, isReadOnly, locale) {
                 label: kieli.metadata[localeUpper].nimi,
                 value: kieli.koodiarvo
               };
-            }, takeLast(4, data.kieletOPH)),
-            callback: (payload, values) => {
-              console.log(values.value[0]);
-            },
-            title: __("common.valitseYksiTaiUseampi"),
+            }, valittavanaOlevatToissisijaisetOpetuskielet),
+            title: __("common.valitseYksiTaiUseampi")
           }
         }
       ]
@@ -65,8 +100,7 @@ export function opetuskielet(data, isReadOnly, locale) {
           name: "StatusTextRow",
           styleClasses: ["pt-8 border-t"],
           properties: {
-            title:
-              __("common.lisatiedotInfo")
+            title: __("common.lisatiedotInfo")
           }
         }
       ]

--- a/src/services/lomakkeet/index.js
+++ b/src/services/lomakkeet/index.js
@@ -33,7 +33,7 @@ import getYhteenvetoYleisetTiedotLomake from "./yhteenveto/yleisetTiedot";
 import getTopThree from "./esittelija";
 import { opetusJotaLupaKoskee } from "./esi-ja-perusopetus/1-opetus-jota-lupa-koskee";
 import getPaatoksenTiedot from "./esi-ja-perusopetus/0-paatoksenTiedot";
-import { opetuskielet } from "./esi-ja-perusopetus/3-opetuskielet";
+import { getOpetuskieletOPHLomake } from "./esi-ja-perusopetus/3-opetuskielet";
 import { opetuksenJarjestamismuoto } from "./esi-ja-perusopetus/4-opetuksenJarjestamismuoto";
 import { erityisetKoulutustehtavat } from "./esi-ja-perusopetus/5-erityisetKoulutustehtavat";
 import { muutEhdot } from "./esi-ja-perusopetus/7-muutEhdot";
@@ -313,8 +313,8 @@ const lomakkeet = {
         opetusJotaLupaKoskee(data, isReadOnly, locale)
     },
     opetuskielet: {
-      modification: (data, isReadOnly, locale) =>
-        opetuskielet(data, isReadOnly, locale)
+      modification: (data, isReadOnly, locale, changeObjects) =>
+        getOpetuskieletOPHLomake(data, isReadOnly, locale, changeObjects)
     },
     opiskelijamaarat: {
       modification: (data, isReadOnly, locale) =>


### PR DESCRIPTION
# Oleellisimmat huomioitavat asiat

* kieletOPH:n jakaminen kahteen eri muuttujaan: ensisijaisetOpetuskieletOPH ja toissijaisetOpetuskieletOPH
* Pudotusvalikoissa ei näytetä niitä kieliä, jotka ovat jo valittuina.
* Komponenttipuolelle kohdistui myös muutoksia.