### PR TITLE
CSCOIVA-1594: Fokus kun tekstikenttien lisäys- ja poistotoiminnallisuutta käytetään näppäimistöllä

### DIFF
--- a/src/components/00-atoms/SimpleButton/index.js
+++ b/src/components/00-atoms/SimpleButton/index.js
@@ -33,6 +33,7 @@ const styles = createStyles(theme => ({
 }));
 
 const SimpleButton = ({
+  id,
   isReadOnly = defaultProps.isReadOnly,
   onClick,
   payload = defaultProps.payload,
@@ -55,6 +56,7 @@ const SimpleButton = ({
     <React.Fragment>
       {!isReadOnly && (
         <Button
+          id={id}
           size={size}
           onClick={handleClick}
           variant={variant}
@@ -65,13 +67,9 @@ const SimpleButton = ({
           aria-label={ariaLabel}
           className={classes.root}>
           {icon && (
-            <span style={ iconContainerStyles }>
-              {icon === "FaPlus" && (
-                <FaPlus style={ iconStyles }/>
-              )}
-              {icon === "ClearIcon" && (
-                <ClearIcon style={ iconStyles }/>
-                )}
+            <span style={iconContainerStyles}>
+              {icon === "FaPlus" && <FaPlus style={iconStyles} />}
+              {icon === "ClearIcon" && <ClearIcon style={iconStyles} />}
             </span>
           )}
           {text}
@@ -85,6 +83,7 @@ SimpleButton.propTypes = {
   ariaLabel: PropTypes.string,
   color: PropTypes.string,
   disabled: PropTypes.bool,
+  id: PropTypes.string,
   isReadOnly: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   payload: PropTypes.object,

--- a/src/components/00-atoms/TextBox/index.js
+++ b/src/components/00-atoms/TextBox/index.js
@@ -262,7 +262,6 @@ const TextBox = props => {
 TextBox.defaultProps = {
   ariaLabel: "Text area",
   delay: 300,
-  shouldHaveFocus: false,
   isDisabled: false,
   isHidden: false,
   payload: {},
@@ -282,7 +281,7 @@ TextBox.defaultProps = {
 TextBox.propTypes = {
   ariaLabel: PropTypes.string,
   delay: PropTypes.number,
-  shouldHaveFocus: PropTypes.bool,
+  shouldHaveFocus: PropTypes.number,
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   isHidden: PropTypes.bool,

--- a/src/components/00-atoms/TextBox/index.js
+++ b/src/components/00-atoms/TextBox/index.js
@@ -93,6 +93,7 @@ const textboxStyles = {
 };
 
 const TextBox = props => {
+  const { onFocus } = props;
   const [isVisited, setIsVisited] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const { classes } = props;
@@ -114,8 +115,9 @@ const TextBox = props => {
   useEffect(() => {
     if (props.shouldHaveFocus) {
       textBoxRef.current.focus();
+      onFocus();
     }
-  }, [props.shouldHaveFocus]);
+  }, [onFocus, props.shouldHaveFocus]);
 
   return (
     <React.Fragment>
@@ -281,7 +283,7 @@ TextBox.defaultProps = {
 TextBox.propTypes = {
   ariaLabel: PropTypes.string,
   delay: PropTypes.number,
-  shouldHaveFocus: PropTypes.number,
+  shouldHaveFocus: PropTypes.bool,
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   isHidden: PropTypes.bool,

--- a/src/components/00-atoms/TextBox/index.js
+++ b/src/components/00-atoms/TextBox/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import TextareaAutosize from "@material-ui/core/TextareaAutosize";
 import PropTypes from "prop-types";
 import Tooltip from "../../02-organisms/Tooltip";
@@ -97,8 +97,12 @@ const TextBox = props => {
   const [isFocused, setIsFocused] = useState(false);
   const { classes } = props;
 
+  const textBoxRef = useRef(null);
+
   const updateValue = e => {
-    props.onChanges(props.payload, { value: e.target.value });
+    props.onChanges(props.payload, {
+      value: e.target.value
+    });
   };
 
   const deleteTextBox = () => {
@@ -106,6 +110,12 @@ const TextBox = props => {
       deleteElement: true
     });
   };
+
+  useEffect(() => {
+    if (props.shouldHaveFocus) {
+      textBoxRef.current.focus();
+    }
+  }, [props.shouldHaveFocus]);
 
   return (
     <React.Fragment>
@@ -156,6 +166,7 @@ const TextBox = props => {
                 placeholder={
                   props.isDisabled || props.isReadOnly ? "" : props.placeholder
                 }
+                ref={textBoxRef}
                 rows={props.isReadOnly ? 1 : props.rows}
                 rowsMax={props.isReadOnly ? Infinity : props.rowsMax}
                 className={`${props.isHidden ? "hidden" : "rounded"} 
@@ -251,6 +262,7 @@ const TextBox = props => {
 TextBox.defaultProps = {
   ariaLabel: "Text area",
   delay: 300,
+  shouldHaveFocus: false,
   isDisabled: false,
   isHidden: false,
   payload: {},
@@ -270,6 +282,7 @@ TextBox.defaultProps = {
 TextBox.propTypes = {
   ariaLabel: PropTypes.string,
   delay: PropTypes.number,
+  shouldHaveFocus: PropTypes.bool,
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   isHidden: PropTypes.bool,

--- a/src/components/01-molecules/CheckboxWithLabel/index.js
+++ b/src/components/01-molecules/CheckboxWithLabel/index.js
@@ -23,6 +23,7 @@ import Check from "@material-ui/icons/CheckBoxOutlined";
 const CheckboxWithLabel = React.memo(
   ({
     children,
+    id,
     isChecked,
     isDisabled,
     isIndeterminate,
@@ -61,6 +62,7 @@ const CheckboxWithLabel = React.memo(
               control={
                 <Checkbox
                   checked={isChecked}
+                  id={id}
                   indeterminate={isChecked && isIndeterminate}
                   value="1"
                   onChange={handleChanges}
@@ -105,6 +107,7 @@ CheckboxWithLabel.defaultProps = {
 };
 
 CheckboxWithLabel.propTypes = {
+  id: PropTypes.string,
   isChecked: PropTypes.bool,
   isDisabled: PropTypes.bool,
   isIndeterminate: PropTypes.bool,

--- a/src/components/01-molecules/RadioButtonWithLabel/index.js
+++ b/src/components/01-molecules/RadioButtonWithLabel/index.js
@@ -22,7 +22,12 @@ const RadioButtonWithLabel = React.memo(
         }
       },
       checked: {}
-    })(props => <Radio color="default" {...props} />);
+    })(props => (
+      <Radio
+        color="default"
+        {...props}
+      />
+    ));
 
     const handleChanges = () => {
       props.onChanges(props.payload, { isChecked: !props.isChecked });

--- a/src/components/02-organisms/CategorizedListRoot/CategorizedList/index.js
+++ b/src/components/02-organisms/CategorizedListRoot/CategorizedList/index.js
@@ -115,7 +115,7 @@ const getPropertiesObject = (
  * form structure will be gone through again and so the form will be updated.
  */
 const CategorizedList = props => {
-  const { onChangesUpdate, showValidationErrors } = props;
+  const { onChangesUpdate, onFocus, showValidationErrors } = props;
 
   /**
    * Click of the SimpleButton is handled here.
@@ -502,6 +502,7 @@ const CategorizedList = props => {
                               isRequired={propsObj.isRequired}
                               isValid={propsObj.isValid}
                               onChanges={handleChanges}
+                              onFocus={onFocus}
                               payload={{
                                 anchor,
                                 categories: category.categories,
@@ -511,7 +512,7 @@ const CategorizedList = props => {
                                 rootPath: props.rootPath
                               }}
                               placeholder={propsObj.placeholder}
-                              shouldHaveFocus={propsObj.shouldHaveFocus}
+                              shouldHaveFocus={props.focusOn === fullAnchor}
                               title={propsObj.title}
                               tooltip={propsObj.tooltip}
                               value={propsObj.value}
@@ -906,6 +907,7 @@ const CategorizedList = props => {
             category.categories && (
               <CategorizedList
                 anchor={anchor}
+                focusOn={props.focusOn}
                 categories={category.categories}
                 changes={categoryChanges}
                 debug={props.debug}
@@ -922,6 +924,7 @@ const CategorizedList = props => {
                 runRootOperations={props.runRootOperations}
                 showCategoryTitles={props.showCategoryTitles}
                 onChangesUpdate={props.onChangesUpdate}
+                onFocus={props.onFocus}
                 showValidationErrors={showValidationErrors}
                 requiredMessage={props.requiredMessage}
               />
@@ -939,6 +942,7 @@ CategorizedList.defaultProps = {
 
 CategorizedList.propTypes = {
   anchor: PropTypes.string,
+  focusOn: PropTypes.string,
   categories: PropTypes.array,
   changes: PropTypes.array,
   debug: PropTypes.bool,
@@ -947,7 +951,8 @@ CategorizedList.propTypes = {
   runRootOperations: PropTypes.func,
   showCategoryTitles: PropTypes.bool,
   onChangesUpdate: PropTypes.func,
-  onChangesRemove: PropTypes.func
+  onChangesRemove: PropTypes.func,
+  onFocus: PropTypes.func
 };
 
 CategorizedList.displayName = "CategorizedList222";

--- a/src/components/02-organisms/CategorizedListRoot/CategorizedList/index.js
+++ b/src/components/02-organisms/CategorizedListRoot/CategorizedList/index.js
@@ -447,15 +447,13 @@ const CategorizedList = props => {
                           );
                           const isDisabled =
                             propsObj.isReadOnly ||
-                            (
-                              (previousSibling.name === "CheckboxWithLabel" ||
-                                previousSibling.name ===
+                            ((previousSibling.name === "CheckboxWithLabel" ||
+                              previousSibling.name ===
                                 "RadioButtonWithLabel") &&
                               !(
                                 isPreviousSiblingCheckedByDefault ||
                                 change.properties.isChecked
-                              )
-                            );
+                              ));
                           return (
                             <div
                               className={component.styleClasses || "px-2 mb-1"}>
@@ -513,6 +511,7 @@ const CategorizedList = props => {
                                 rootPath: props.rootPath
                               }}
                               placeholder={propsObj.placeholder}
+                              shouldHaveFocus={propsObj.shouldHaveFocus}
                               title={propsObj.title}
                               tooltip={propsObj.tooltip}
                               value={propsObj.value}
@@ -778,7 +777,9 @@ const CategorizedList = props => {
                                 height={heights.SHORT}
                                 short={component.short}
                                 title={propsObj.title}
-                                hideSelectedOptions={propsObj.hideSelectedOptions}
+                                hideSelectedOptions={
+                                  propsObj.hideSelectedOptions
+                                }
                               />
                             </div>
                           );
@@ -806,6 +807,7 @@ const CategorizedList = props => {
                     {component.name === "SimpleButton" && (
                       <div className={`${component.styleClasses} flex-2`}>
                         <SimpleButton
+                          id={fullAnchor}
                           isReadOnly={propsObj.isReadOnly}
                           text={propsObj.text}
                           variant={propsObj.variant}

--- a/src/components/02-organisms/CategorizedListRoot/index.js
+++ b/src/components/02-organisms/CategorizedListRoot/index.js
@@ -19,8 +19,10 @@ const defaultProps = {
 const CategorizedListRoot = React.memo(
   ({
     anchor = defaultProps.anchor,
+    focusOn,
     categories = defaultProps.categories,
     changes = defaultProps.changes,
+    onFocus,
     onUpdate,
     showCategoryTitles = defaultProps.showCategoryTitles,
     isReadOnly,
@@ -105,11 +107,13 @@ const CategorizedListRoot = React.memo(
               return (
                 <CategorizedList
                   anchor={anchor}
+                  focusOn={focusOn}
                   categories={categories}
                   changes={changes}
                   rootPath={[]}
                   showCategoryTitles={showCategoryTitles}
                   onChangesUpdate={onChangesUpdate}
+                  onFocus={onFocus}
                   removeChangeObject={removeChangeObject}
                   isReadOnly={isReadOnly}
                   showValidationErrors={showValidationErrors}
@@ -132,12 +136,16 @@ const CategorizedListRoot = React.memo(
 CategorizedListRoot.propTypes = {
   // Root anchor of the form. Dots are not allowed.
   anchor: PropTypes.string,
+  // Anchor of the element that should have focus
+  focusOn: PropTypes.string,
   // Structure of the form. Array of categories.
   categories: PropTypes.array,
   // Array of change objects.
   changes: PropTypes.array,
   // Callback function that will be called when something changes on the form.
   onUpdate: PropTypes.func.isRequired,
+  // Should be called when a component sets focus on some of its elements.
+  onFocus: PropTypes.func,
   // Categories might have titles. The boolean defines if are going to be shown.
   showCategoryTitles: PropTypes.bool,
   // Defines if the form can be modified.

--- a/src/components/02-organisms/ExpandableRowRoot/index.js
+++ b/src/components/02-organisms/ExpandableRowRoot/index.js
@@ -7,6 +7,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import UndoIcon from "@material-ui/icons/Undo";
 import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
+import { compose, filter, not, pathEq } from "ramda";
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -53,6 +54,11 @@ const ExpandableRowRoot = ({
     setIsToggleOpen(props[1]);
   };
 
+  const amountOfRelevantChanges = filter(
+    compose(not, pathEq(["properties", "metadata", "isOnlyForUI"], true)),
+    changes
+  );
+
   return (
     <React.Fragment>
       {categories && (
@@ -65,10 +71,14 @@ const ExpandableRowRoot = ({
             <span>{title}</span>
           </h4>
           <div data-slot="info">
-            {changes.length > 0 && (
+            {amountOfRelevantChanges.length > 0 && (
               <div className="flex items-center">
                 {!hideAmountOfChanges && (
-                  <NumberOfChanges changes={changes} id={anchor} messages={messages} />
+                  <NumberOfChanges
+                    changes={amountOfRelevantChanges}
+                    id={anchor}
+                    messages={messages}
+                  />
                 )}
                 {!disableReverting && (
                   <span className="mx-6">

--- a/src/components/02-organisms/Lomake/index.js
+++ b/src/components/02-organisms/Lomake/index.js
@@ -3,7 +3,10 @@ import PropTypes from "prop-types";
 import CategorizedListRoot from "../CategorizedListRoot";
 import { getLomake } from "../../../services/lomakkeet";
 import { useIntl } from "react-intl";
-import { useChangeObjectsByAnchorWithoutUnderRemoval } from "../../../scenes/AmmatillinenKoulutus/store";
+import {
+  useChangeObjects,
+  useChangeObjectsByAnchorWithoutUnderRemoval
+} from "../../../scenes/AmmatillinenKoulutus/store";
 import ExpandableRowRoot from "../ExpandableRowRoot";
 import formMessages from "i18n/definitions/lomake";
 import { has, isEmpty } from "ramda";
@@ -47,7 +50,7 @@ const Lomake = ({
         changesTest: intl.formatMessage(formMessages.changesText)
       }
     : rowMessages;
-
+  const [{ focusOn }] = useChangeObjects();
   const [changeObjects, actions] = useChangeObjectsByAnchorWithoutUnderRemoval({
     anchor
   });
@@ -67,6 +70,10 @@ const Lomake = ({
     },
     [actions]
   );
+
+  const onFocus = useCallback(() => {
+    actions.setFocusOn(null);
+  }, [actions]);
 
   useEffect(() => {
     async function fetchLomake() {
@@ -117,8 +124,10 @@ const Lomake = ({
             <div className={noPadding ? "" : "p-8"}>
               <CategorizedListRoot
                 anchor={anchor}
+                focusOn={focusOn}
                 categories={lomake}
                 changes={changeObjects}
+                onFocus={onFocus}
                 onUpdate={onChangesUpdate}
                 showCategoryTitles={showCategoryTitles}
                 showValidationErrors={showValidationErrors}
@@ -132,8 +141,10 @@ const Lomake = ({
           <div className={noPadding ? "" : "p-8"}>
             <CategorizedListRoot
               anchor={anchor}
+              focusOn={focusOn}
               categories={lomake}
               changes={changeObjects}
+              onFocus={onFocus}
               onUpdate={onChangesUpdate}
               showCategoryTitles={showCategoryTitles}
               showValidationErrors={showValidationErrors}

--- a/src/components/02-organisms/Lomake/index.js
+++ b/src/components/02-organisms/Lomake/index.js
@@ -22,117 +22,98 @@ const defaultProps = {
   uncheckParentWithoutActiveChildNodes: false
 };
 
-const Lomake = React.memo(
-  ({
+const Lomake = ({
+  action,
+  anchor,
+  data = defaultProps.data,
+  isInExpandableRow = defaultProps.isInExpandableRow,
+  isReadOnly,
+  isRowExpanded = defaultProps.isRowExpanded,
+  path: _path,
+  prefix = defaultProps.prefix,
+  showCategoryTitles = defaultProps.showCategoryTitles,
+  uncheckParentWithoutActiveChildNodes = defaultProps.uncheckParentWithoutActiveChildNodes,
+  hasInvalidFieldsFn,
+  noPadding = defaultProps.noPadding,
+  rowMessages = defaultProps.rowMessages,
+  rowTitle = defaultProps.rowTitle,
+  showValidationErrors = defaultProps.showValidationErrors
+}) => {
+  const intl = useIntl();
+
+  const rowLocalizations = isEmpty(rowMessages)
+    ? {
+        undo: intl.formatMessage(formMessages.undo),
+        changesTest: intl.formatMessage(formMessages.changesText)
+      }
+    : rowMessages;
+
+  const [changeObjects, actions] = useChangeObjectsByAnchorWithoutUnderRemoval({
+    anchor
+  });
+  const [, lomakedataActions] = useLomakedata({ anchor });
+  const [lomake, setLomake] = useState();
+
+  const onChangesRemove = useCallback(
+    anchor => {
+      actions.setChanges([], anchor);
+    },
+    [actions]
+  );
+
+  const onChangesUpdate = useCallback(
+    ({ anchor, changes }) => {
+      actions.setChanges(changes, anchor);
+    },
+    [actions]
+  );
+
+  useEffect(() => {
+    async function fetchLomake() {
+      return await getLomake(
+        action,
+        changeObjects,
+        data,
+        isReadOnly,
+        intl.locale,
+        _path,
+        prefix
+      );
+    }
+
+    fetchLomake().then(result => {
+      if (has("isValid", result)) {
+        lomakedataActions.setValidity(result.isValid, anchor);
+      }
+      result.structure ? setLomake(result.structure) : setLomake(result);
+    });
+  }, [
     action,
     anchor,
-    data = defaultProps.data,
-    isInExpandableRow = defaultProps.isInExpandableRow,
-    isReadOnly,
-    isRowExpanded = defaultProps.isRowExpanded,
-    path: _path,
-    prefix = defaultProps.prefix,
-    showCategoryTitles = defaultProps.showCategoryTitles,
-    uncheckParentWithoutActiveChildNodes = defaultProps.uncheckParentWithoutActiveChildNodes,
+    changeObjects,
+    data,
     hasInvalidFieldsFn,
-    noPadding = defaultProps.noPadding,
-    rowMessages = defaultProps.rowMessages,
-    rowTitle = defaultProps.rowTitle,
-    showValidationErrors = defaultProps.showValidationErrors
-  }) => {
-    const intl = useIntl();
+    isReadOnly,
+    intl.locale,
+    lomakedataActions,
+    _path,
+    prefix
+  ]);
 
-    const rowLocalizations = isEmpty(rowMessages)
-      ? {
-          undo: intl.formatMessage(formMessages.undo),
-          changesTest: intl.formatMessage(formMessages.changesText)
-        }
-      : rowMessages;
-
-    const [
-      changeObjects,
-      actions
-    ] = useChangeObjectsByAnchorWithoutUnderRemoval({
-      anchor
-    });
-    const [, lomakedataActions] = useLomakedata({ anchor });
-    const [lomake, setLomake] = useState();
-
-    const onChangesRemove = useCallback(
-      anchor => {
-        actions.setChanges([], anchor);
-      },
-      [actions]
-    );
-
-    const onChangesUpdate = useCallback(
-      ({ anchor, changes }) => {
-        actions.setChanges(changes, anchor);
-      },
-      [actions]
-    );
-
-    useEffect(() => {
-      async function fetchLomake() {
-        return await getLomake(
-          action,
-          changeObjects,
-          data,
-          isReadOnly,
-          intl.locale,
-          _path,
-          prefix
-        );
-      }
-
-      fetchLomake().then(result => {
-        if (has("isValid", result)) {
-          lomakedataActions.setValidity(result.isValid, anchor);
-        }
-        result.structure ? setLomake(result.structure) : setLomake(result);
-      });
-    }, [
-      action,
-      anchor,
-      changeObjects,
-      data,
-      hasInvalidFieldsFn,
-      isReadOnly,
-      intl.locale,
-      lomakedataActions,
-      _path,
-      prefix
-    ]);
-
-    if (lomake) {
-      return (
-        <React.Fragment>
-          {isInExpandableRow ? (
-            <ExpandableRowRoot
-              anchor={anchor}
-              changes={changeObjects}
-              key={`expandable-row-root`}
-              hideAmountOfChanges={true}
-              isExpanded={isRowExpanded}
-              onChangesRemove={onChangesRemove}
-              messages={rowLocalizations}
-              sectionId={anchor}
-              title={rowTitle}>
-              <div className={noPadding ? "" : "p-8"}>
-                <CategorizedListRoot
-                  anchor={anchor}
-                  categories={lomake}
-                  changes={changeObjects}
-                  onUpdate={onChangesUpdate}
-                  showCategoryTitles={showCategoryTitles}
-                  showValidationErrors={showValidationErrors}
-                  uncheckParentWithoutActiveChildNodes={
-                    uncheckParentWithoutActiveChildNodes
-                  }
-                />
-              </div>
-            </ExpandableRowRoot>
-          ) : (
+  if (lomake) {
+    return (
+      <React.Fragment>
+        {isInExpandableRow ? (
+          <ExpandableRowRoot
+            anchor={anchor}
+            changes={changeObjects}
+            key={`expandable-row-root`}
+            hideAmountOfChanges={true}
+            isExpanded={isRowExpanded}
+            onChangesRemove={onChangesRemove}
+            messages={rowLocalizations}
+            sectionId={anchor}
+            title={rowTitle}>
             <div className={noPadding ? "" : "p-8"}>
               <CategorizedListRoot
                 anchor={anchor}
@@ -146,14 +127,28 @@ const Lomake = React.memo(
                 }
               />
             </div>
-          )}
-        </React.Fragment>
-      );
-    } else {
-      return <div>Lomakkeen kenttiä ei voida näyttää.</div>;
-    }
+          </ExpandableRowRoot>
+        ) : (
+          <div className={noPadding ? "" : "p-8"}>
+            <CategorizedListRoot
+              anchor={anchor}
+              categories={lomake}
+              changes={changeObjects}
+              onUpdate={onChangesUpdate}
+              showCategoryTitles={showCategoryTitles}
+              showValidationErrors={showValidationErrors}
+              uncheckParentWithoutActiveChildNodes={
+                uncheckParentWithoutActiveChildNodes
+              }
+            />
+          </div>
+        )}
+      </React.Fragment>
+    );
+  } else {
+    return <div>Lomakkeen kenttiä ei voida näyttää.</div>;
   }
-);
+};
 
 Lomake.propTypes = {
   action: PropTypes.string,

--- a/src/i18n/definitions/common.js
+++ b/src/i18n/definitions/common.js
@@ -1178,5 +1178,21 @@ export default defineMessages({
   voimassaoleva: {
     id: "common.voimassaoleva",
     defaultMessage: "Voimassaoleva"
+  },
+  lupaSisaltaaYhteistyosopimuksia: {
+    id: "common.lupaSisaltaaYhteistyosopimuksia",
+    defaultMessage: "Lupa sisältää yhteistyösopimuksia"
+  },
+  maarayksenKuvaus: {
+    id: "common.maarayksenKuvaus",
+    defaultMessage: "Määräyksen kuvaus"
+  },
+  maarayksenXKuvaus: {
+    id: "common.maarayksenXKuvaus",
+    defaultMessage: "Määräyksen {nro} kuvaus"
+  },
+  lisaaUusiYhteistyosopimus: {
+    id: "common.lisaaUusiYhteistyosopimus",
+    defaultMessage: "Lisää uusi yhteistyösopimus"
   }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import "./wdyr";
+// import "./wdyr";
 import React from "react";
 import { render } from "react-dom";
 import { ThroughProvider } from "react-through";

--- a/src/scenes/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/08-Yhteistyosopimus/index.js
+++ b/src/scenes/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/08-Yhteistyosopimus/index.js
@@ -25,6 +25,7 @@ const Yhteistyosopimus = ({
       action="modification"
       anchor={sectionId}
       data={dataLomakepalvelulle}
+      isRowExpanded={true}
       path={constants.formLocation}
       rowTitle={items[0].metadata[localeUpper].nimi}
       showCategoryTitles={true}

--- a/src/scenes/AmmatillinenKoulutus/store.js
+++ b/src/scenes/AmmatillinenKoulutus/store.js
@@ -86,7 +86,6 @@ const Store = createStore({
               metadata: {
                 focusWhenDeleted: "erityisetKoulutustehtavat.2.0.kuvaus"
               },
-              lisaa: true,
               value: ""
             }
           },
@@ -96,8 +95,7 @@ const Store = createStore({
               metadata: {
                 focusWhenDeleted: "erityisetKoulutustehtavat.2.0.kuvaus"
               },
-              shouldHaveFocus: true,
-              lisaa: true,
+              shouldHaveFocus: +new Date(),
               value: ""
             }
           },
@@ -129,7 +127,6 @@ const Store = createStore({
             metadata: {
               focusWhenDeleted: "erityisetKoulutustehtavat.2.0.kuvaus"
             },
-            lisaa: true,
             value: ""
           }
         },
@@ -139,8 +136,7 @@ const Store = createStore({
             metadata: {
               focusWhenDeleted: "erityisetKoulutustehtavat.2.0.kuvaus"
             },
-            shouldHaveFocus: true,
-            lisaa: true,
+            shouldHaveFocus: +new Date(),
             value: ""
           }
         },
@@ -158,8 +154,12 @@ const Store = createStore({
     addCriterion: (sectionId, rajoiteId) => ({ getState, setState }) => {
       const currentChangeObjects = getState().changeObjects;
       const rajoitekriteeritChangeObjects = filter(
-        changeObj => startsWith(`${sectionId}.${rajoiteId}.asetukset`, changeObj.anchor) &&
-          !startsWith(`${sectionId}.${rajoiteId}.asetukset.kohde`, changeObj.anchor),
+        changeObj =>
+          startsWith(`${sectionId}.${rajoiteId}.asetukset`, changeObj.anchor) &&
+          !startsWith(
+            `${sectionId}.${rajoiteId}.asetukset.kohde`,
+            changeObj.anchor
+          ),
         concat(
           currentChangeObjects.unsaved[sectionId] || [],
           currentChangeObjects.saved[sectionId] || []
@@ -173,12 +173,12 @@ const Store = createStore({
       const nextCriterionAnchorPart =
         length(rajoitekriteeritChangeObjects) > 0
           ? reduce(
-          max,
-          -Infinity,
-          map(changeObj => {
-            return parseInt(getAnchorPart(changeObj.anchor, 3), 10);
-          }, rajoitekriteeritChangeObjects)
-        ) + 1
+              max,
+              -Infinity,
+              map(changeObj => {
+                return parseInt(getAnchorPart(changeObj.anchor, 3), 10);
+              }, rajoitekriteeritChangeObjects)
+            ) + 1
           : 1;
 
       /**
@@ -207,6 +207,7 @@ const Store = createStore({
       setState
     }) => {
       if (sectionId) {
+        const splittedSectionId = split("_", sectionId);
         const currentChangeObjects = getState().changeObjects;
         const textBoxChangeObjects = filter(
           changeObj =>
@@ -277,13 +278,13 @@ const Store = createStore({
         setState({ ...getState(), changeObjects: nextChangeObjects });
       }
     },
-    initializeChanges: changeObjects => ({dispatch}) => {
+    initializeChanges: changeObjects => ({ dispatch }) => {
       dispatch(setSavedChanges(changeObjects));
       dispatch(setLatestChanges({}));
       dispatch(removeUnderRemoval());
       dispatch(removeUnsavedChanges());
     },
-    removeChangeObjectByAnchor: anchor => ({getState, setState}) => {
+    removeChangeObjectByAnchor: anchor => ({ getState, setState }) => {
       const allCurrentChangeObjects = getState().changeObjects;
       const anchorParts = split("_", getAnchorPart(anchor, 0));
       const unsavedFullPath = prepend("unsaved", anchorParts);
@@ -367,9 +368,9 @@ const Store = createStore({
       );
       setState(assoc("changeObjects", nextChangeObjects, getState()));
     },
-    showNewRestrictionDialog: () => ({getState, setState}) => {
-      setState({...getState(), isRestrictionDialogVisible: true});
-    },
+    showNewRestrictionDialog: () => ({ getState, setState }) => {
+      setState({ ...getState(), isRestrictionDialogVisible: true });
+    }
   },
   name: "Muutokset"
 });
@@ -442,15 +443,22 @@ export const useChangeObjectsByAnchorWithoutUnderRemoval = createHook(Store, {
   selector: getChangeObjectsByAnchorWithoutUnderRemoval
 });
 
-export const useChangeObjectsByMultipleAnchorsWithoutUnderRemoval = createHook(Store, {
-  selector: (state, { anchors }) => {
-   return mergeAll(map(anchor => {
-      return {
-        [anchor]: getChangeObjectsByAnchorWithoutUnderRemoval(state, {anchor})
-      }
-    }, anchors))
+export const useChangeObjectsByMultipleAnchorsWithoutUnderRemoval = createHook(
+  Store,
+  {
+    selector: (state, { anchors }) => {
+      return mergeAll(
+        map(anchor => {
+          return {
+            [anchor]: getChangeObjectsByAnchorWithoutUnderRemoval(state, {
+              anchor
+            })
+          };
+        }, anchors)
+      );
+    }
   }
-});
+);
 
 export const useChangeObjects = createHook(Store);
 

--- a/src/scenes/EsiJaPerusopetus/UusiAsiaEsidialog.js
+++ b/src/scenes/EsiJaPerusopetus/UusiAsiaEsidialog.js
@@ -221,7 +221,7 @@ const UusiAsiaEsidialog = ({ isVisible, onClose, onSelect }) => {
                   setSelectedKJ(values.value);
                 }}
                 title={""}
-                value={selectedKJ}
+                value={[selectedKJ]}
               />
               <p className="my-4">
                 {intl.formatMessage(common.luoUusiAsiaEsidialogiInfo2)}

--- a/src/scenes/EsiJaPerusopetus/lomake/5-ErityisetKoulutustehtavat.js
+++ b/src/scenes/EsiJaPerusopetus/lomake/5-ErityisetKoulutustehtavat.js
@@ -25,7 +25,7 @@ const ErityisetKoulutustehtavat = ({ sectionId }) => {
     <Lomake
       action="modification"
       anchor={sectionId}
-      data={{ onAddButtonClick }}
+      data={{ onAddButtonClick, sectionId }}
       isRowExpanded={true}
       path={constants.formLocations}
       showCategoryTitles={true}

--- a/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
@@ -81,7 +81,12 @@ export async function erityisetKoulutustehtavat(
                         name: "TextBox",
                         properties: {
                           forChangeObject: {
-                            focusWhenDeleted: `${data.sectionId}.${erityinenKoulutustehtava.koodiarvo}.0.kuvaus`
+                            focusWhenDeleted: `${data.sectionId}.${
+                              erityinenKoulutustehtava.koodiarvo
+                            }.${parseInt(
+                              getAnchorPart(changeObj.anchor, 2) - 1,
+                              10
+                            )}.kuvaus`
                           },
                           isReadOnly,
                           isRemovable: true,

--- a/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
@@ -7,13 +7,11 @@ import {
   find,
   flatten,
   map,
-  nth,
   path,
   pathEq,
   prop,
   propEq,
   sortBy,
-  split,
   startsWith,
   toUpper
 } from "ramda";

--- a/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
@@ -36,7 +36,7 @@ export async function erityisetKoulutustehtavat(
   return flatten([
     map(erityinenKoulutustehtava => {
       const changeObj = getChangeObjByAnchor(
-        `erityisetKoulutustehtavat.${erityinenKoulutustehtava.koodiarvo}.valintaelementti`,
+        `${data.sectionId}.${erityinenKoulutustehtava.koodiarvo}.valintaelementti`,
         changeObjects
       );
 
@@ -80,6 +80,9 @@ export async function erityisetKoulutustehtavat(
                         anchor: "kuvaus",
                         name: "TextBox",
                         properties: {
+                          forChangeObject: {
+                            focusWhenDeleted: `${data.sectionId}.${erityinenKoulutustehtava.koodiarvo}.0.kuvaus`
+                          },
                           isReadOnly,
                           isRemovable: true,
                           placeholder: __("common.kuvausPlaceholder"),
@@ -93,12 +96,12 @@ export async function erityisetKoulutustehtavat(
                 filter(
                   changeObj =>
                     startsWith(
-                      `erityisetKoulutustehtavat.${erityinenKoulutustehtava.koodiarvo}`,
+                      `${data.sectionId}.${erityinenKoulutustehtava.koodiarvo}`,
                       changeObj.anchor
                     ) &&
                     endsWith(".kuvaus", changeObj.anchor) &&
                     !startsWith(
-                      `erityisetKoulutustehtavat.${erityinenKoulutustehtava.koodiarvo}.0`,
+                      `${data.sectionId}.${erityinenKoulutustehtava.koodiarvo}.0`,
                       changeObj.anchor
                     ),
                   changeObjects

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -252,11 +252,144 @@ const isSubTreeEmpty = obj => {
 
 export const isTreeEmpty = obj => R.isEmpty(isSubTreeEmpty(obj));
 
-const removeOldLeaves = (branchOfTree = [], property = "deleteElement") => {
-  return R.filter(leaf => {
-    return !R.pathEq(["properties", property], true, leaf);
-  }, branchOfTree);
+/**
+ * Poistaa lehden (muutosobjekti). Mikäli muutosobjektiin on merkitty
+ * mihin kohtaan muutosten puuta huomio (fokus) tulee seuraavaksi siirtää,
+ * hoidetaan huomion siirtäminen.
+ * @param {*} leaf
+ * @param {*} branch
+ * @param {*} tree
+ */
+// const removeLeaf = (leaf, branch, tree) => {
+//   const shouldHaveFocusPath = ["properties", "shouldHaveFocus"];
+// const focusWhenDeleted = R.path(
+//   ["properties", "metadata", "focusWhenDeleted"],
+//   leaf
+// );
+//   /* Jos lehti sisältää tiedon siitä, mihin mihin huomio on
+//    * seuraavaksi kohdistettava, pidetään huoli, että näin käy. Luodaan
+//    * vaikka tarvittaessa uusi muutosobjekti.
+//    **/
+//   console.info("Poistetaan lehti: ", leaf, branch, tree);
+//   if (!!focusWhenDeleted) {
+//     let updatedTree =
+//     const changeObj = R.find(
+//       R.propEq("anchor", focusWhenDeleted),
+//       R.path(R.split("_", getAnchorPart(focusWhenDeleted, 0)), tree.unsaved)
+//     );
+//     if (changeObj && !R.pathEq(shouldHaveFocusPath, true, changeObj)) {
+//       const p = R.split("_", getAnchorPart(changeObj.anchor, 0));
+//       const leavesToWalkThrough = R.path(p, tree.unsaved);
+//       console.info("Leaves to walk trough: ", leavesToWalkThrough);
+//       const updatedTree = R.assocPath(
+//         R.prepend("unsaved", p),
+//         map(leaves => {
+//           console.info("Lehdet: ", leaves);
+//           return leaves;
+//         }, leavesToWalkThrough),
+//         tree
+//       );
+
+//       console.info("Asetetaan fokus", leaf, changeObj);
+//     }
+//   }
+//   return null;
+// };
+
+const updateLeaf = (p, leafWithNewData, tree) => {
+  const anchor = R.prop("anchor", leafWithNewData);
+  const branch = R.map(leaf => {
+    return leaf.anchor === anchor ? leafWithNewData : leaf;
+  }, R.path(p, tree));
+  return R.assocPath(p, branch, tree);
 };
+
+const setFocusOnLeaf = (anchors, tree, index = 0) => {
+  const anchor = R.nth(index, anchors);
+  if (anchor) {
+    console.info(anchor, anchors, index);
+    const p = R.prepend("unsaved", R.split("_", getAnchorPart(anchor, 0)));
+    const leafToUpdate = R.find(
+      R.propEq("anchor", anchor),
+      R.path(R.split("_", getAnchorPart(anchor, 0)), tree.unsaved)
+    );
+    const updatedLeaf = R.assocPath(
+      ["properties", "shouldHaveFocus"],
+      +new Date(), // Current timestamp in milliseconds
+      leafToUpdate
+    );
+    const updatedTree = updateLeaf(p, updatedLeaf, tree);
+    if (!!R.nth(index + 1, anchors)) {
+      return setFocusOnLeaf(anchors, updatedTree, index + 1);
+    } else {
+      return updatedTree;
+    }
+  }
+  return tree;
+};
+
+const removeOldLeaves = (p = [], tree) => {
+  const branch = R.path(p, tree);
+  const leavesToRemove = R.filter(
+    R.pathEq(["properties", "deleteElement"], true),
+    branch
+  );
+  const updatedTree = setFocusOnLeaf(
+    R.map(
+      R.path(["properties", "metadata", "focusWhenDeleted"]),
+      leavesToRemove
+    ),
+    tree
+  );
+  return updatedTree;
+
+  /**
+   * Jos poistettavissa lehdissä on merkintä seuraavasta fokusoitavasta
+   * elementistä, tehdään puuhun merkintöjen mukaiset operaatiot.
+   */
+
+  // const updatedTree = R.assocPath(p, , tree)
+
+  // R.map(leaf => {
+  //   // Poistetaan lehti, jos se on asetettu poistettavaksi.
+  //   if (R.pathEq(["properties", property], true, leaf)) {
+  //     return removeLeaf(leaf, branchOfTree, tree);
+  //   } else {
+  //     // Jos lehteä ei ole asetettu poistettavaksi, palautetaan nykyinen lehti.
+  //     return leaf;
+  //   }
+  // }, branchOfTree);
+};
+
+// const setShouldBeFocused = (branchOfTree = [], tree) => {
+//   const shouldHaveFocusPath = ["properties", "shouldHaveFocus"];
+//   const changeObjects = R.map(leaf => {
+//     const { focusWhenDeleted } = leaf.properties.metadata || {};
+//     /**
+//      * Jos lehti sisältää tiedon siitä, mihin mihin huomio on
+//      * seuraavaksi kohdistettava, pidetään huoli, että näin käy. Luodaan
+//      * vaikka tarvittaessa uusi muutosobjekti.
+//      **/
+//     if (!!focusWhenDeleted) {
+//       const changeObj = R.find(
+//         R.propEq("anchor", focusWhenDeleted),
+//         R.path(R.split("_", getAnchorPart(focusWhenDeleted, 0)), tree.unsaved)
+//       );
+//       /**
+//        * Jos kyseistä lomakkeen kohtaa on jo muokattu eli on olemassa
+//        * muutosobjekti, päivitetään muutosobjektia siten, että tietoja käyttävä
+//        * komponentti saa tiedon siitä, että komponentin sisältämän elementin
+//        * tulisi olla kohdennettu.
+//        */
+//       if (changeObj && !R.pathEq(shouldHaveFocusPath, true, changeObj)) {
+//         console.info("Asetetaan fokus", leaf, changeObj);
+//         return [leaf, R.assocPath(shouldHaveFocusPath, true, changeObj)];
+//       }
+//     }
+//     return leaf;
+//   }, branchOfTree).filter(Boolean);
+//   return R.uniq(R.flatten(changeObjects));
+// };
 
 const protectedTreeProps = ["unsaved", "underRemoval"];
 
@@ -267,30 +400,52 @@ const protectedTreeProps = ["unsaved", "underRemoval"];
  * @param {*} tree Objekti, josta polku etsitään läpi käytäväksi
  */
 export const recursiveTreeShake = (p = [], tree) => {
-  const subTree = R.path(p, tree);
-  const subTreeWithoutFlaggedAsDeleted = Array.isArray(subTree)
-    ? removeOldLeaves(subTree)
-    : subTree;
-  const isSubTreeEmpty = isTreeEmpty(subTreeWithoutFlaggedAsDeleted);
+  // Poistetaan käsiteltävänä olevasta oksasta vanhat lehdet.
+  const updatedTree = removeOldLeaves(p, tree);
 
-  /**
-   * Tyhjän alipuun voi poistaa, kunhan huomioidaan se, ettei poisteta
-   * puusta "suojeltuja" propertyjä, jotka on määritelty
-   * protectedTreeProps-muuttujassa.
-   */
-  if (!R.includes(R.last(p), protectedTreeProps)) {
-    if (isSubTreeEmpty) {
-      let updatedTree = R.dissocPath(p, tree);
-      if (isTreeEmpty(R.init(p), updatedTree)) {
-        updatedTree = R.dissocPath(R.init(p), tree);
-      }
-      if (R.length(p)) {
-        return recursiveTreeShake(R.init(p), updatedTree);
-      }
+  // let subTreeWithFocusProps = Array.isArray(subTree)
+  //   ? setShouldBeFocused(subTree, tree)
+  //   : subTree;
+  // const subTreeWithoutFlaggedAsDeleted = Array.isArray(subTree)
+  //   ? removeLeaves(subTree, tree)
+  //   : subTree;
+  // const isSubTreeEmpty = isTreeEmpty(subTreeWithoutFlaggedAsDeleted);
+
+  // /**
+  //  * Tyhjän alipuun voi poistaa, kunhan huomioidaan se, ettei poisteta
+  //  * puusta "suojeltuja" propertyjä, jotka on määritelty
+  //  * protectedTreeProps-muuttujassa.
+  //  */
+  // if (!R.includes(R.last(p), protectedTreeProps)) {
+  //   if (isSubTreeEmpty) {
+  //     let updatedTree = R.dissocPath(p, tree);
+  //     if (isTreeEmpty(R.init(p), updatedTree)) {
+  //       updatedTree = R.dissocPath(R.init(p), tree);
+  //     }
+  //     if (R.length(p)) {
+  //       return recursiveTreeShake(R.init(p), updatedTree);
+  //     }
+  //   } else {
+  //     tree = R.assocPath(p, subTreeWithoutFlaggedAsDeleted, tree);
+  //   }
+  // }
+  return updatedTree;
+};
+
+/**
+ * Käy annetun oksan (branch) lehdet (muutosobjektit) läpi ja
+ * palauttaa niistä uudet versiot hyödyntäen parametrinä annettua funktiota.
+ * Mikäli oksa sisältää alioksia, kutsuu modifyLeavesOfBranch itseään
+ * parametreinä fn ja alioksa.
+ * @param {*} fn Funktio, joka palauttaa oksan lehdistä uudet versiot.
+ * @param {*} branch Objekti (puu), joka käydään läpi.
+ */
+export const modifyLeavesOfBranch = (fn, branch) => {
+  return R.mapObjIndexed(subBranch => {
+    if (Array.isArray(subBranch)) {
+      return fn(subBranch);
     } else {
-      tree = R.assocPath(p, subTreeWithoutFlaggedAsDeleted, tree);
+      return modifyLeavesOfBranch(fn, subBranch);
     }
-  }
-
-  return tree;
+  }, branch);
 };

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -303,21 +303,3 @@ export const recursiveTreeShake = (p = [], branch, dispatch) => {
   }
   return updatedBranch;
 };
-
-/**
- * Käy annetun oksan (branch) lehdet (muutosobjektit) läpi ja
- * palauttaa niistä uudet versiot hyödyntäen parametrinä annettua funktiota.
- * Mikäli oksa sisältää alioksia, kutsuu modifyLeavesOfBranch itseään
- * parametreinä fn ja alioksa.
- * @param {*} fn Funktio, joka palauttaa oksan lehdistä uudet versiot.
- * @param {*} branch Objekti (puu), joka käydään läpi.
- */
-export const modifyLeavesOfBranch = (fn, branch) => {
-  return R.mapObjIndexed(subBranch => {
-    if (Array.isArray(subBranch)) {
-      return fn(subBranch);
-    } else {
-      return modifyLeavesOfBranch(fn, subBranch);
-    }
-  }, branch);
-};


### PR DESCRIPTION
* Suunniteltu ja toteutettu mekanismi fokuksen asettamiseksi. Fokuksen siirtymistä voi hallita lomakepalvelun puolella lomakemerkkauksesta käsin asettamalla komponentille forChangeObject-objektiin ominaisuuden `focusWhenDeleted` ja arvoksi jonkin lomakkeen ankkurin. Tilanhallintaa on laajennettu `focusOn`-ominaisuudella, joka välitetään komponenteille Lomake-komponenttia hyödyntäen.

* Otettu ratkaisu käyttöön PO-puolen osiossa 5. Mikäli ratkaisu todetaan toimivaksi katselmoinnin myötä, voidaan kirjoittaa Jiraan uudet issuet sen mukaan, mihin muihin osioihin ratkaisu on otettava käyttöön.