### PR TITLE
Cscoiva 1664 ja CSCOIVA-1676

### DIFF
--- a/src/components/02-organisms/Asiakirjat/index.js
+++ b/src/components/02-organisms/Asiakirjat/index.js
@@ -27,6 +27,7 @@ import SelectAttachment from "components/02-organisms/SelectAttachment";
 import ProcedureHandler from "components/02-organisms/procedureHandler";
 import ConfirmDialog from "../ConfirmDialog";
 import * as R from "ramda";
+import Typography from "@material-ui/core/Typography";
 
 const WrapTable = styled.div``;
 
@@ -411,7 +412,7 @@ const Asiakirjat = ({ koulutusmuoto }) => {
           </Link>
           <div className="flex-1 flex items-center pt-8 pb-2">
             <div className="w-full flex flex-col">
-              <h1>{nimi}</h1>
+              <Typography component="h1" variant="h1">{nimi}</Typography>
               <h5 className="text-lg mt-1">{ytunnus}</h5>
             </div>
           </div>
@@ -421,8 +422,10 @@ const Asiakirjat = ({ koulutusmuoto }) => {
             style={{ maxWidth: "90rem" }}
             className="flex-1 flex flex-col w-full mx-auto px-3 lg:px-8 pb-12">
             <span>
-              <h4 className="mb-2 float-left">{t(common.asianAsiakirjat)}</h4>
-              <h4 className="float-right">
+              <Typography component="h4" variant="h4" className="float-left">
+                {t(common.asianAsiakirjat)}
+              </Typography>
+              <Typography component="h4" variant="h4" className="float-right" style={{margin: 0, padding: 0}}>
                 <SelectAttachment
                   attachmentAdded={handleAddPaatoskirje}
                   messages={{
@@ -445,7 +448,7 @@ const Asiakirjat = ({ koulutusmuoto }) => {
                   }}
                   fileType={"paatosKirje"}
                 />
-              </h4>
+              </Typography>
             </span>
             {isDeleteLiiteDialogVisible && (
               <ConfirmDialog

--- a/src/components/02-organisms/Asiakirjat/index.js
+++ b/src/components/02-organisms/Asiakirjat/index.js
@@ -425,7 +425,7 @@ const Asiakirjat = ({ koulutusmuoto }) => {
               <Typography component="h4" variant="h4" className="float-left">
                 {t(common.asianAsiakirjat)}
               </Typography>
-              <Typography component="h4" variant="h4" className="float-right" style={{margin: 0, padding: 0}}>
+              <Typography component="h4" variant="h4" className="float-right" style={{margin: 0}}>
                 <SelectAttachment
                   attachmentAdded={handleAddPaatoskirje}
                   messages={{

--- a/src/components/03-templates/Section/index.js
+++ b/src/components/03-templates/Section/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Typography from "@material-ui/core/Typography";
 
 const defaultProps = {
   code: "",
@@ -14,7 +15,7 @@ const Section = ({
   const fullTitle = `${code ? `${code}. ` : ""}${title}`;
   return (
     <div>
-      {fullTitle && <h2 className="pt-8 pb-4">{fullTitle}</h2>}
+      {fullTitle && <Typography component="h2" variant="h2" className="pt-8">{fullTitle}</Typography>}
       <div className="pb-4">{children}</div>
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ theme.typography.h1 = {
 theme.typography.h2 = {
   fontSize: "1.5rem",
   fontWeight: 500,
+  marginBottom: "1rem",
   [theme.breakpoints.down("xs")]: {
     fontSize: "1.375rem"
   }
@@ -53,12 +54,14 @@ theme.typography.h2 = {
 
 theme.typography.h3 = {
   fontSize: "1.2rem",
-  fontWeight: 500
+  fontWeight: 500,
+  marginBottom: "1rem"
 };
 
 theme.typography.h4 = {
   fontSize: "1rem",
-  fontWeight: 500
+  fontWeight: 500,
+  marginBottom: "1rem"
 };
 
 theme.typography.p = {

--- a/src/modules/Loading.js
+++ b/src/modules/Loading.js
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import common from "../i18n/definitions/common";
 import PropTypes from "prop-types";
 import * as R from "ramda";
+import Typography from "@material-ui/core/Typography";
 
 const Loading = ({ notReadyList = [], percentage, text }) => {
   const intl = useIntl();
@@ -17,7 +18,7 @@ const Loading = ({ notReadyList = [], percentage, text }) => {
         )}
         <CircularProgress size={80} value={percentage} />
       </span>
-      <h3 className="ml-4">{loadingtext}...</h3>
+      <Typography component="h3" variant="h3" className="ml-4">{loadingtext}...</Typography>
       <ul className="ml-10">
         {R.addIndex(R.map)((item, i) => {
           return <li key={`${item}-${i}`}>{item}</li>;

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/LupaSection.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/LupaSection.js
@@ -14,6 +14,7 @@ import common from "i18n/definitions/common";
 import { useIntl } from "react-intl";
 import { parseLocalizedField } from "modules/helpers";
 import { find } from "ramda";
+import Typography from "@material-ui/core/Typography";
 
 const Otsikko = styled.div`
   font-size: 16px;
@@ -95,9 +96,9 @@ const LupaSection = props => {
     const section = list =>
       list.length > 0 ? (
         <MuutSection>
-          <h4>
+          <Typography component="h4" variant="h4">
             <Bold>{list[0].tyyppi}</Bold>
-          </h4>
+          </Typography>
           {_.map(list, (item, i) => {
             const { kuvaus } = item;
             return (
@@ -325,9 +326,9 @@ const LupaSection = props => {
                 const { tyyppi, kuvaus } = muu;
                 return (
                   <MuutSection key={i}>
-                    <h4>
+                    <Typography component="h4" variant="h4">
                       <Bold>{tyyppi}</Bold>
-                    </h4>
+                    </Typography>
                     <Kuvaus>{kuvaus}</Kuvaus>
                   </MuutSection>
                 );

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/index.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/index.js
@@ -44,13 +44,13 @@ const JarjestamislupaJSX = ({ lupa, lupakohteet }) => {
   return !!kielet ? (
     <div>
       {lupaException ? (
-        <TopSectionWrapper className="py-16">
+        <TopSectionWrapper className="pb-4">
           <Typography component="h2" variant="h5">
             {intl.formatMessage(titleMessageKey, { date: "" })}
           </Typography>
         </TopSectionWrapper>
       ) : (
-        <TopSectionWrapper className="py-16">
+        <TopSectionWrapper className="pb-4">
           <Typography component="h2" variant="h5">
             {intl.formatMessage(titleMessageKey, { date: dateString })}
           </Typography>

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
@@ -16,6 +16,7 @@ import {
 import { useIntl } from "react-intl";
 import education from "../../../../i18n/definitions/education";
 import { getPOErityisetKoulutustehtavatFromStorage } from "helpers/poErityisetKoulutustehtavat";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetuksenErityisetKoulutustehtavatHtml({
   maaraykset
@@ -45,12 +46,19 @@ export default function PoOpetuksenErityisetKoulutustehtavatHtml({
     maaraykset
   );
 
+  const lisatietomaarays = find(
+    maarays =>
+      maarays.kohde.tunniste === "erityinenkoulutustehtava" &&
+      maarays.koodisto === "lisatietoja",
+    maaraykset
+  );
+
   return !isEmpty(erityisetKoulutustehtavat) &&
     !isEmpty(erityisetKoulutustehtavatKoodisto) ? (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">
+      <Typography component="h3" variant="h3">
         {intl.formatMessage(education.erityisetKoulutustehtavat)}
-      </h3>
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         {map(erityinenKoulutustehtava => {
           const koodistonTiedot = find(
@@ -90,6 +98,7 @@ export default function PoOpetuksenErityisetKoulutustehtavatHtml({
           Boolean
         )}
       </ul>
+      { lisatietomaarays ? (lisatietomaarays.meta.arvo) : null}
     </div>
   ) : null;
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/index.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/index.js
@@ -10,6 +10,7 @@ import PoOpetusJotaLupaKoskeeHtml from "./opetusJotaLupaKoskee";
 import moment from "moment";
 import PoOpetustaAntavatKunnatHtml from "./opetustaAntavatKunnat";
 import PoOpiskelijamaaratHtml from "./opiskelijamaarat";
+import Typography from "@material-ui/core/Typography";
 
 /**
  * Funktio rakentaa esi- ja perusopetuksen HTML-lupanäkymän.
@@ -20,12 +21,12 @@ const JarjestamislupaJSX = ({ lupa }) => {
 
   return (
     <React.Fragment>
-      <h2 className="font-medium mb-6">
+      <Typography component="h2" variant="h2">
         {formatMessage(common.htmlLuvanOtsikko, {
           date: moment().format("DD.MM.YYYY"),
           koulutusmuodon: "esi- ja perusopetuksen",
         })}
-      </h2>
+      </Typography>
 
       <PoOpetusJotaLupaKoskeeHtml maaraykset={lupa.maaraykset} />
       <PoOpetustaAntavatKunnatHtml maaraykset={lupa.maaraykset} />

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
@@ -16,6 +16,7 @@ import {
 import { useIntl } from "react-intl";
 import education from "../../../../i18n/definitions/education";
 import { getPOMuutEhdotFromStorage } from "helpers/poMuutEhdot";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetuksenMuutEhdotHtml({ maaraykset }) {
   const intl = useIntl();
@@ -38,11 +39,18 @@ export default function PoOpetuksenMuutEhdotHtml({ maaraykset }) {
     maaraykset
   );
 
+  const lisatietomaarays = find(
+    maarays =>
+      maarays.kohde.tunniste === "muutkoulutuksenjarjestamiseenliittyvatehdot" &&
+      maarays.koodisto === "lisatietoja",
+    maaraykset
+  );
+
   return !isEmpty(muutEhdot) && !isEmpty(muutEhdotKoodisto) ? (
-    <div className={"pt-8 pb-4"}>
-      <h3 className="font-medium mb-4">
+    <div className="mt-4">
+      <Typography component="h3" variant="h3">
         {intl.formatMessage(education.muutEhdotTitle)}
-      </h3>
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         {map(muuEhto => {
           const koodistonTiedot = find(
@@ -82,6 +90,7 @@ export default function PoOpetuksenMuutEhdotHtml({ maaraykset }) {
           Boolean
         )}
       </ul>
+      { lisatietomaarays ? (lisatietomaarays.meta.arvo) : null}
     </div>
   ) : null;
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetuksenJarjestamismuoto.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetuksenJarjestamismuoto.js
@@ -2,6 +2,7 @@ import React from "react";
 import { find, includes } from "ramda";
 import { useIntl } from "react-intl";
 import education from "../../../../i18n/definitions/education";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetuksenJarjestamismuotoHtml({ maaraykset }) {
   const intl = useIntl();
@@ -21,12 +22,15 @@ export default function PoOpetuksenJarjestamismuotoHtml({ maaraykset }) {
 
   return opetuksenJarjestamismuoto ? (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">{intl.formatMessage(education.opetuksenJarjestamismuoto)}</h3>
+      <Typography component="h3" variant="h3">
+        {intl.formatMessage(education.opetuksenJarjestamismuoto)}
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         <li key={opetuksenJarjestamismuoto.koodiarvo}>
           {jarjestamismuodonKuvaus}
         </li>
       </ul>
+      { lisatietomaarays && (lisatietomaarays.meta.arvo)}
     </div>
   ) : null
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetusJotaLupaKoskee.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetusJotaLupaKoskee.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { filter, find, map, toUpper, isEmpty, propEq } from "ramda";
 import { useIntl } from "react-intl";
 import { getOpetustehtavatFromStorage, getOpetustehtavaKoodistoFromStorage } from "../../../../helpers/opetustehtavat";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetusJotaLupaKoskeeHtml({ maaraykset }) {
   const intl = useIntl();
@@ -36,7 +37,9 @@ export default function PoOpetusJotaLupaKoskeeHtml({ maaraykset }) {
 
   return !isEmpty(opetustehtavat) && !isEmpty(opetustehtavaKoodisto) && !isEmpty(opetustehtavatFromStorage) && (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">{opetustehtavaKoodisto.metadata[toUpper(intl.locale)].kuvaus}</h3>
+      <Typography component="h3" variant="h3">
+        {opetustehtavaKoodisto.metadata[toUpper(intl.locale)].kuvaus}
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         {
           map(opetustehtava =>
@@ -47,6 +50,7 @@ export default function PoOpetusJotaLupaKoskeeHtml({ maaraykset }) {
           opetustehtavat)
         }
       </ul>
+      { lisatietomaarays && (lisatietomaarays.meta.arvo)}
     </div>
   )
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetuskielet.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetuskielet.js
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import common from "../../../../i18n/definitions/common";
 import education from "../../../../i18n/definitions/education";
 import { getKieletOPHFromStorage } from "../../../../helpers/opetuskielet";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetuskieletHtml({ maaraykset }) {
   const intl = useIntl();
@@ -32,7 +33,9 @@ export default function PoOpetuskieletHtml({ maaraykset }) {
 
   return ( (!isEmpty(ensisijaisetOpetuskielet) || !isEmpty(toissijaisetOpetuskielet)) && !isEmpty(kieletOPH)) && (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">{intl.formatMessage(common.opetuskieli)}</h3>
+      <Typography component="h3" variant="h3">
+        {intl.formatMessage(common.opetuskieli)}
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         {
           map(opetuskieli =>
@@ -43,7 +46,9 @@ export default function PoOpetuskieletHtml({ maaraykset }) {
         }
       </ul>
       {!isEmpty(toissijaisetOpetuskielet) &&
-      <h4 className="font-medium mb-4">{intl.formatMessage(education.voidaanAntaaMyosSeuraavillaKielilla)}</h4>}
+      <Typography component="h4" variant="h4">
+        {intl.formatMessage(education.voidaanAntaaMyosSeuraavillaKielilla)}
+      </Typography>}
       <ul className="ml-8 list-disc mb-4">
         {
           map(opetuskieli =>
@@ -53,6 +58,7 @@ export default function PoOpetuskieletHtml({ maaraykset }) {
             toissijaisetOpetuskielet || [])
         }
       </ul>
+      { lisatietomaarays && (lisatietomaarays.meta.arvo)}
     </div>
   )
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetustaAntavatKunnat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opetustaAntavatKunnat.js
@@ -19,6 +19,7 @@ import { useIntl } from "react-intl";
 import education from "../../../../i18n/definitions/education";
 import { getKunnatFromStorage } from "../../../../helpers/kunnat";
 import { getMaakuntakunnat } from "../../../../helpers/maakunnat";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpetustaAntavatKunnatHtml({ maaraykset }) {
   const intl = useIntl();
@@ -54,6 +55,10 @@ export default function PoOpetustaAntavatKunnatHtml({ maaraykset }) {
     return !isEmpty(maakuntaKunnat) ? find(propEq("koodiarvo", maakunta.koodiarvo), maakuntaKunnat).kunnat : null
   }, maakuntaMaaraykset);
 
+  const lisatietomaarays = find(maarays =>
+    maarays.kohde.tunniste === "kunnatjoissaopetustajarjestetaan"
+    && maarays.koodisto === "lisatietoja", maaraykset);
+
   const opetustaJarjestetaanUlkomaillaValintaMaarays = find(maarays =>
     maarays.kohde.tunniste === "kunnatjoissaopetustajarjestetaan" &&
     !isNil(path(["meta", "changeObjects"], maarays)) &&
@@ -61,7 +66,7 @@ export default function PoOpetustaAntavatKunnatHtml({ maaraykset }) {
     startsWith("toimintaalue.ulkomaa", maarays.meta.changeObjects[0].anchor) , maaraykset)
 
   const opetustaJarjestetaanUlkomaillaIsChecked = opetustaJarjestetaanUlkomaillaValintaMaarays &&
-    opetustaJarjestetaanUlkomaillaValintaMaarays.meta.changeObjects[0].properties.isChecked;
+    path(["meta", "changeObjects", "0", "properties", "isChecked"], opetustaJarjestetaanUlkomaillaValintaMaarays);
 
   const opetustaJarjestetaanUlkomaillaLisatiedotMaarays = find(maarays =>
     maarays.kohde.tunniste === "kunnatjoissaopetustajarjestetaan" &&
@@ -79,9 +84,11 @@ export default function PoOpetustaAntavatKunnatHtml({ maaraykset }) {
     }, flatten(concat(kunnatFromMaakuntaMaaraykset, kuntaMaaraykset)).filter(Boolean))
   );
 
-  return !isEmpty(kunnat) && !isEmpty(maakuntaKunnat) && !isEmpty(kunnatFromLupa) ? (
+  return !isEmpty(kunnat) && !isEmpty(maakuntaKunnat) && (!isEmpty(kunnatFromLupa) || opetustaJarjestetaanUlkomaillaIsChecked) ? (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">{intl.formatMessage(education.opetustaAntavatKunnat)}</h3>
+      <Typography component="h3" variant="h3">
+        {intl.formatMessage(education.opetustaAntavatKunnat)}
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         {
           map(kunta =>
@@ -91,11 +98,14 @@ export default function PoOpetustaAntavatKunnatHtml({ maaraykset }) {
         }
       </ul>
       { opetustaJarjestetaanUlkomaillaIsChecked && (
-        <div>
-          <h4 className="font-medium mb-4">{intl.formatMessage(education.opetustaJarjestetaanSuomenUlkopuolella)}</h4>
+        <div className="mb-4">
+          <Typography component="h4" variant="h4">
+            {intl.formatMessage(education.opetustaJarjestetaanSuomenUlkopuolella)}
+          </Typography>
           {opetustaJarjestetaanUlkomaillaLisatiedotMaarays ? opetustaJarjestetaanUlkomaillaLisatiedotMaarays.meta.arvo : ""}
         </div>
       )}
+      { lisatietomaarays && (lisatietomaarays.meta.arvo)}
     </div>
   ) : null
 }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opiskelijamaarat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/opiskelijamaarat.js
@@ -3,6 +3,7 @@ import { find } from "ramda";
 import { useIntl } from "react-intl";
 import common from "../../../../i18n/definitions/common";
 import education from "../../../../i18n/definitions/education";
+import Typography from "@material-ui/core/Typography";
 
 export default function PoOpiskelijamaaratHtml({ maaraykset }) {
   const intl = useIntl();
@@ -10,9 +11,14 @@ export default function PoOpiskelijamaaratHtml({ maaraykset }) {
   const opiskelijamaaraMaarays = find(maarays => maarays.kohde.tunniste === "oppilasopiskelijamaara" &&
     maarays.koodisto === "kujalisamaareet", maaraykset);
 
+  const lisatietomaarays = find(maarays => maarays.kohde.tunniste === "oppilasopiskelijamaara" &&
+    maarays.koodisto === "lisatietoja", maaraykset);
+
   return opiskelijamaaraMaarays ? (
     <div className="mt-4">
-      <h3 className="font-medium mb-4">{intl.formatMessage(education.oppilasOpiskelijamaarat)}</h3>
+      <Typography component="h3" variant="h3">
+        {intl.formatMessage(education.oppilasOpiskelijamaarat)}
+      </Typography>
       <ul className="ml-8 list-disc mb-4">
         <li className="leading-bulletList">
           {(opiskelijamaaraMaarays.koodiarvo === "1" ?
@@ -20,6 +26,7 @@ export default function PoOpiskelijamaaratHtml({ maaraykset }) {
           opiskelijamaaraMaarays.arvo}
         </li>
       </ul>
+      { lisatietomaarays && (lisatietomaarays.meta.arvo)}
     </div>
   ) : null
 }


### PR DESCRIPTION
Toteutettu tässä sekä CSCOIVA-1664, että CSCOIVA-1676 
- Lisätiedot näkyviin PO html-luvan osioille
- Korjattu PO html-lupa käyttämään Typography-elementtiä h-elementtien sijaan
- Myös Ammatillisen puolen luvalla käytetään nyt Typography-elementtiä.
- Vaihdettu myös muutamaan muuhun paikkaan h-elementti Typography-elementtiin...