### PR TITLE
CSCOIVA-1676: Html lupien otsikoiden fonttityylit

### DIFF
--- a/src/scenes/Koulutusmuodot/VapaaSivistystyo/JarjestamislupaHTML/LupaSection.js
+++ b/src/scenes/Koulutusmuodot/VapaaSivistystyo/JarjestamislupaHTML/LupaSection.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Typography from "@material-ui/core/Typography";
 
 const LupaSection = props => {
   const { kohde } = props;
@@ -12,9 +13,9 @@ const LupaSection = props => {
       <div className="flex">
         <div className="w-full">
           {heading && (
-            <h2 className="py-8">
+            <Typography component="h3" variant="h3">
               <span>{heading}</span>
-            </h2>
+            </Typography>
           )}
           <div className="pb-4">{elements}</div>
         </div>

--- a/src/scenes/Koulutusmuodot/VapaaSivistystyo/JarjestamislupaHTML/index.js
+++ b/src/scenes/Koulutusmuodot/VapaaSivistystyo/JarjestamislupaHTML/index.js
@@ -74,8 +74,8 @@ const JarjestamislupaJSX = ({ lupa }) => {
 
   return (
     <div>
-      <Typography variant="h2">{lupaTitle}</Typography>
-      <div className="p-8">
+      <Typography variant="h2" component="h2">{lupaTitle}</Typography>
+      <div>
         {sections.map((sectionData, i) => {
           return <LupaSection key={i} kohde={sectionData || {}} />;
         })}


### PR DESCRIPTION
-Korjattu VST puolen html-lupien otsikoiden tyylejä