### PR TITLE
CSCOIVA-1679: Asiat -sivun tyylit

### DIFF
--- a/src/components/03-templates/Asiat/index.js
+++ b/src/components/03-templates/Asiat/index.js
@@ -14,6 +14,7 @@ import UusiAsiaEsidialog from "../UusiAsiaEsidialog";
 import { last, split } from "ramda";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
 import commonMessages from "../../../i18n/definitions/common";
+import Typography from "@material-ui/core/Typography";
 
 const OivaTab = withStyles(theme => ({
   root: {
@@ -78,9 +79,14 @@ const Asiat = ({ koulutusmuoto, path, user }) => {
       <div className="flex flex-col justify-end mx-auto w-4/5">
         <div className="flex items-center">
           <div className="flex-1">
+            <Typography component="h1" variant="h1">
+              {t(common.asianhallinta)}
+            </Typography>
             <div className="w-full flex flex-row justify-between">
-              <div></div>
-              <div className="pt-3 my-auto">
+              <Typography component="h2" variant="h2" style={{ fontSize: "1.25rem", padding: 0, fontWeight: 400}}>
+                {koulutusmuoto.paasivunOtsikko}
+              </Typography>
+              <div>
                 <SimpleButton
                   aria-label={t(common.luoUusiAsia)}
                   color="primary"

--- a/src/components/03-templates/Esittelijat/index.js
+++ b/src/components/03-templates/Esittelijat/index.js
@@ -3,7 +3,6 @@ import { useUser } from "../../../stores/user";
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
-import { Typography } from "@material-ui/core";
 import BaseData from "basedata";
 import Asiat from "../Asiat";
 import Asiakirjat from "components/02-organisms/Asiakirjat";
@@ -13,7 +12,6 @@ import { MuutoksetContainer } from "../../../stores/muutokset";
 const Esittelijat = ({
   AsiaDialogContainer,
   koulutusmuoto,
-  paasivunOtsikko,
   UusiAsiaDialogContainer
 }) => {
   const { formatMessage, locale } = useIntl();
@@ -28,17 +26,6 @@ const Esittelijat = ({
       </BreadcrumbsItem>
 
       <article className="flex-1 flex-col flex">
-        <div className="mx-auto w-4/5">
-          <Typography component="h1" variant="h1">
-            {formatMessage(commonMessages.asiat)}
-          </Typography>
-          <Typography
-            component="h2"
-            style={{ fontSize: "1.25rem" }}
-            className="pb-4 mt--12">
-            {koulutusmuoto.kortinOtsikko}
-          </Typography>
-        </div>
 
         <Switch>
           <Route

--- a/src/components/03-templates/KoulutusmuodonEtusivu/index.js
+++ b/src/components/03-templates/KoulutusmuodonEtusivu/index.js
@@ -118,7 +118,7 @@ export default function KoulutusmuodonEtusivu({
                     <Asianhallinta
                       AsiaDialogContainer={AsiaDialogContainer}
                       koulutusmuoto={koulutusmuoto}
-                      sivunOtsikko={paasivunOtsikko}
+                      paasivunOtsikko={paasivunOtsikko}
                       UusiAsiaDialogContainer={UusiAsiaDialogContainer}
                     />
                   )}

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,8 @@ theme.typography.h1 = {
   fontSize: "2rem",
   fontWeight: 500,
   lineHeight: "1.2",
-  marginBottom: "1rem",
-  marginTop: "1rem",
+  paddingBottom: "1rem",
+  paddingTop: "1rem",
   [theme.breakpoints.down("xs")]: {
     fontSize: "1.875rem"
   }
@@ -46,7 +46,9 @@ theme.typography.h1 = {
 theme.typography.h2 = {
   fontSize: "1.5rem",
   fontWeight: 500,
-  marginBottom: "1rem",
+  lineHeight: "1.275",
+  paddingBottom: "1rem",
+  paddingTop: "1rem",
   [theme.breakpoints.down("xs")]: {
     fontSize: "1.375rem"
   }
@@ -55,17 +57,21 @@ theme.typography.h2 = {
 theme.typography.h3 = {
   fontSize: "1.2rem",
   fontWeight: 500,
-  marginBottom: "1rem"
+  lineHeight: "1.3",
+  paddingBottom: "1rem",
+  paddingTop: "1rem"
 };
 
 theme.typography.h4 = {
   fontSize: "1rem",
   fontWeight: 500,
-  marginBottom: "1rem"
+  lineHeight: "1.5",
+  paddingBottom: "1rem",
+  paddingTop: "1rem"
 };
 
 theme.typography.p = {
-  marginBottom: "1.5rem"
+  paddingBottom: "1.5rem"
 };
 
 theme.palette.primary.main = COLORS.OIVA_GREEN;

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
@@ -13,6 +13,7 @@ import MuutospyyntoWizardTopThree from "scenes/Koulutusmuodot/AmmatillinenKoulut
 import Lomake from "components/02-organisms/Lomake";
 import * as R from "ramda";
 import Tutkintokielet from "scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Kielet/Tutkintokielet";
+import Typography from "@material-ui/core/Typography";
 
 const constants = {
   formLocation: {
@@ -130,25 +131,25 @@ const EsittelijatMuutospyynto = ({
       <form onSubmit={handleSubmit}>
         <Section>
           <div className="w-1/3">
-            <h2 className="p-8" style={{ marginLeft: "-2rem" }}>
+            <Typography component="h2" variant="h2">
               {intl.formatMessage(common.decisionDetails)}
-            </h2>
+            </Typography>
             <MuutospyyntoWizardTopThree />
           </div>
         </Section>
-        <h2 className="my-6">{intl.formatMessage(common.changesText)}</h2>
+        <Typography component="h2" variant="h2">{intl.formatMessage(common.changesText)}</Typography>
         <Section
           code={sectionHeadings.tutkinnotJaKoulutukset.number}
           title={sectionHeadings.tutkinnotJaKoulutukset.title}>
-          <h4 className="pb-4">{intl.formatMessage(common.tutkinnot)}</h4>
+          <Typography component="h4" variant="h4">{intl.formatMessage(common.tutkinnot)}</Typography>
           <Tutkinnot
             koulutusalat={koulutusalat}
             koulutustyypit={koulutustyypit}
             tutkinnot={tutkinnot}
           />
-          <h4 className="pt-8 pb-4">
+          <Typography component="h4" variant="h4">
             {intl.formatMessage(common.koulutukset)}
-          </h4>
+          </Typography>
           <MuutospyyntoWizardKoulutukset
             koulutukset={koulutukset}
             maaraykset={maaraykset}

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Kielet/Tutkintokielet.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Kielet/Tutkintokielet.js
@@ -5,6 +5,7 @@ import { useLomakedata } from "stores/lomakedata";
 import Koulutusala from "./Koulutusala";
 import { map, toUpper } from "ramda";
 import wizard from "i18n/definitions/wizard";
+import Typography from "@material-ui/core/Typography";
 
 const Tutkintokielet = ({ koulutusalat }) => {
   const sectionId = "kielet_tutkintokielet";
@@ -16,7 +17,7 @@ const Tutkintokielet = ({ koulutusalat }) => {
 
   return (
     <React.Fragment>
-      <h4 className="py-4">{intl.formatMessage(wizard.tutkintokielet)}</h4>
+      <Typography component="h4" variant="h4">{intl.formatMessage(wizard.tutkintokielet)}</Typography>
       {map(koulutusala => {
         if (tutkintodata[koulutusala.koodiarvo]) {
           return (


### PR DESCRIPTION
-Asetettu typography h-elementeille paddingTop ja paddingBottom 1rem
-Käytetään ammatillisen puolen muutospyyntölomakkeella Typography-elementtejä
