### PR TITLE
CSCOIVA-1701: Toiminta-alueiden muokkaaminen ei onnistu

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-datepicker": "^1.5.0",
     "react-dom": "^16.10.2",
     "react-dropzone": "^11.2.0",
+    "react-fast-compare": "^3.2.0",
     "react-helmet": "^6.0.0-beta",
     "react-icons": "^3.3.0",
     "react-idle-timer": "^4.3.6",

--- a/src/basedata.js
+++ b/src/basedata.js
@@ -3,22 +3,22 @@ import PropTypes from "prop-types";
 import { API_BASE_URL } from "modules/constants";
 import Loading from "modules/Loading";
 import {
-  isEmpty,
-  sortBy,
-  prop,
-  map,
-  toUpper,
-  includes,
   assoc,
-  path,
-  mapObjIndexed,
-  groupBy,
-  omit,
-  head,
+  find,
   filter,
-  test,
+  groupBy,
+  head,
+  includes,
+  isEmpty,
+  map,
+  mapObjIndexed,
+  omit,
+  path,
+  prop,
   propEq,
-  find
+  sortBy,
+  test,
+  toUpper
 } from "ramda";
 import { initializeTutkinnot } from "helpers/tutkinnot";
 import localforage from "localforage";
@@ -299,7 +299,7 @@ const fetchBaseData = async (
     : undefined;
 
   const ahvenanmaanKunnat =
-    (find(propEq("koodiarvo", "21"), maakuntakunnat) || {}).kunnat || [];
+    (find(propEq("koodiarvo", "21"), maakuntakunnat || []) || {}).kunnat || [];
 
   const result = {
     elykeskukset: raw.elykeskukset,

--- a/src/components/00-atoms/FormTitle/index.js
+++ b/src/components/00-atoms/FormTitle/index.js
@@ -6,25 +6,17 @@ const defaultProps = {
   level: 2
 };
 
-const FormTitle = ({
-  code,
-  isPreviewModeOn,
-  level = defaultProps.level,
-  title
-}) => {
+const FormTitle = ({ code, level = defaultProps.level, title }) => {
   return (
-    <div className={`${isPreviewModeOn ? "" : "px-4"}`}>
-      <Typography component={`h${level}`} variant={`h${level}`}>
-        {code ? `${code}. ` : ""}
-        {title}
-      </Typography>
-    </div>
+    <Typography component={`h${level}`} variant={`h${level}`}>
+      {code ? `${code}. ` : ""}
+      {title}
+    </Typography>
   );
 };
 
 FormTitle.propTypes = {
   code: PropTypes.string,
-  isPreviewModeOn: PropTypes.bool,
   level: PropTypes.number,
   title: PropTypes.string
 };

--- a/src/components/02-organisms/CategoryFilter/Modify.js
+++ b/src/components/02-organisms/CategoryFilter/Modify.js
@@ -756,7 +756,6 @@ const Modify = React.memo(
               ]}
               changes={quickFilterChanges}
               onUpdate={payload => {
-                console.info(payload);
                 let { changes } = payload;
                 let nextChanges = null;
                 const activeChange = find(

--- a/src/components/02-organisms/CategoryFilter/categoryFilter.stories.js
+++ b/src/components/02-organisms/CategoryFilter/categoryFilter.stories.js
@@ -39,11 +39,9 @@ storiesOf("CategoryFilter", module)
         changeObjectsByProvince={{}}
         showCategoryTitles={false}
         onChanges={changeObjectsByMaakunta => {
-          console.info(changeObjectsByMaakunta);
           return changeObjectsByMaakunta;
         }}
         toggleEditView={_isEditViewActive => {
-          console.info(_isEditViewActive);
           store.set({ isEditViewActive: _isEditViewActive });
         }}
       />
@@ -73,11 +71,9 @@ storiesOf("CategoryFilter", module)
         changeObjectsByProvince={{}}
         showCategoryTitles={false}
         onChanges={changeObjectsByMaakunta => {
-          console.info(changeObjectsByMaakunta);
           return changeObjectsByMaakunta;
         }}
         toggleEditView={_isEditViewActive => {
-          console.info(_isEditViewActive);
           store.set({ isEditViewActive: _isEditViewActive });
         }}
       />
@@ -107,11 +103,9 @@ storiesOf("CategoryFilter", module)
         changeObjectsByProvince={{}}
         showCategoryTitles={false}
         onChanges={changeObjectsByMaakunta => {
-          console.info(changeObjectsByMaakunta);
           return changeObjectsByMaakunta;
         }}
         toggleEditView={_isEditViewActive => {
-          console.info(_isEditViewActive);
           store.set({ isEditViewActive: _isEditViewActive });
         }}
       />

--- a/src/components/02-organisms/CategoryFilter/utils.js
+++ b/src/components/02-organisms/CategoryFilter/utils.js
@@ -138,12 +138,6 @@ export const handleNodeMain = (
   reducedStructure,
   changes = []
 ) => {
-  console.info(
-    nodeWithRequestedChanges,
-    rootAnchor,
-    reducedStructure,
-    (changes = [])
-  );
   /**
    * node = definition of a component that user has interacted with. Node
    * is an object that includes a name (e.g. CheckboxWithLabel) and the

--- a/src/components/02-organisms/ExpandableRowRoot/index.js
+++ b/src/components/02-organisms/ExpandableRowRoot/index.js
@@ -11,7 +11,7 @@ import { compose, filter, not, pathEq } from "ramda";
 import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles(() => ({
-  button: {
+  noPadding: {
     padding: 0
   }
 }));
@@ -67,7 +67,11 @@ const ExpandableRowRoot = ({
           shouldBeExpanded={isExpanded}
           onToggle={onToggle}
           id={anchor}>
-          <Typography component="h4" variant="h4" data-slot="title">
+          <Typography
+            component="h4"
+            variant="h4"
+            classes={{ root: classes.noPadding }}
+            data-slot="title">
             {code && <span className="pr-6">{code}</span>}
             <span>{title}</span>
           </Typography>
@@ -87,7 +91,7 @@ const ExpandableRowRoot = ({
                       <Button
                         component="span"
                         color="primary"
-                        className={classes.button}
+                        className={classes.noPadding}
                         endIcon={<UndoIcon />}
                         onClick={e => {
                           e.stopPropagation();

--- a/src/components/02-organisms/Lomake/index.js
+++ b/src/components/02-organisms/Lomake/index.js
@@ -9,14 +9,16 @@ import {
 } from "stores/muutokset";
 import ExpandableRowRoot from "../ExpandableRowRoot";
 import formMessages from "i18n/definitions/lomake";
-import { equals, has, isEmpty } from "ramda";
+import { has, isEmpty, omit } from "ramda";
 import { useLomakedata } from "stores/lomakedata";
 import { getReducedStructure } from "../CategorizedListRoot/utils";
 import FormTitle from "components/00-atoms/FormTitle";
 import { getReducedStructureIncludingChanges } from "./utils";
+import equal from "react-fast-compare";
 
 const defaultProps = {
   data: {},
+  functions: {},
   isInExpandableRow: true,
   isPreviewModeOn: false,
   isReadOnly: false,
@@ -36,6 +38,7 @@ const Lomake = React.memo(
     code,
     data = defaultProps.data,
     formTitle,
+    functions = defaultProps.functions,
     isInExpandableRow = defaultProps.isInExpandableRow,
     isPreviewModeOn = defaultProps.isPreviewModeOn,
     isReadOnly = defaultProps.isReadOnly,
@@ -95,11 +98,12 @@ const Lomake = React.memo(
 
     useEffect(() => {
       (async () => {
-        async function fetchLomake(_mode, _changeObjects, _data) {
+        async function fetchLomake(_mode, _changeObjects, _data, _functions) {
           return await getLomake(
             _mode || mode,
             _changeObjects || changeObjects,
             _data || data,
+            _functions || functions,
             { isPreviewModeOn, isReadOnly },
             intl.locale,
             _path,
@@ -138,6 +142,7 @@ const Lomake = React.memo(
       anchor,
       changeObjects,
       data,
+      functions,
       intl.locale,
       isPreviewModeOn,
       isReadOnly,
@@ -209,11 +214,7 @@ const Lomake = React.memo(
     }
   },
   (cp, np) => {
-    return (
-      equals(cp.data, np.data) &&
-      equals(cp.isPreviewModeOn, np.isPreviewModeOn) &&
-      equals(cp.isReadOnly, np.isReadOnly)
-    );
+    return equal(omit(["functions"], cp), omit(["functions"], np));
   }
 );
 
@@ -221,6 +222,7 @@ Lomake.propTypes = {
   anchor: PropTypes.string,
   code: PropTypes.string,
   data: PropTypes.object,
+  functions: PropTypes.object,
   isInExpandableRow: PropTypes.bool,
   isPreviewModeOn: PropTypes.bool,
   isReadOnly: PropTypes.bool,

--- a/src/components/02-organisms/Multiselect/index.js
+++ b/src/components/02-organisms/Multiselect/index.js
@@ -98,7 +98,6 @@ const Multiselect = React.memo(props => {
   // add selected groups from values
   useEffect(() => {
     if (props.options && props.options[0].group) {
-      console.info(props.value);
       const groups =
         props.value &&
         R.filter(option => {

--- a/src/components/02-organisms/Navigation/index.js
+++ b/src/components/02-organisms/Navigation/index.js
@@ -36,7 +36,6 @@ const Navigation = ({
       </a>
     ) : (
       <NavLink
-      className="font-"
         key={`link-${index}`}
         exact={link.isExact}
         activeClassName={`md:bg-${theme.hoverColor} ml-xxs`}

--- a/src/components/02-organisms/procedureHandler/procedures/muutospyynnot/poisto/poista.js
+++ b/src/components/02-organisms/procedureHandler/procedures/muutospyynnot/poisto/poista.js
@@ -5,7 +5,6 @@ export const poista = {
   label: "Muutospyynnön poisto",
   input: ["id"],
   run: async ({ id }) => {
-    console.info(id);
     const response = await deleteDocument("poistaMuutospyynto", {
       urlEnding: id
     });

--- a/src/components/02-organisms/procedureHandler/procedures/muutospyynnot/tilanmuutos/esittelyyn.js
+++ b/src/components/02-organisms/procedureHandler/procedures/muutospyynnot/tilanmuutos/esittelyyn.js
@@ -5,7 +5,6 @@ export const esittelyyn = {
   label: "Muutospyynnön saattaminen esiteltäväksi",
   input: ["id"],
   run: async ({ id }) => {
-    console.info(id);
     const response = await postData(
       "muutospyyntoEsittelyyn",
       {},

--- a/src/components/03-templates/Esittelijat/index.js
+++ b/src/components/03-templates/Esittelijat/index.js
@@ -58,7 +58,18 @@ const Esittelijat = ({
                 koulutustyyppi={koulutusmuoto.koulutustyyppi}
                 render={_props => (
                   <MuutoksetContainer scope={scope}>
-                    <UusiAsiaDialogContainer {..._props} />
+                    <UusiAsiaDialogContainer
+                      kohteet={_props.kohteet}
+                      koulutukset={_props.koulutukset}
+                      koulutusalat={_props.koulutusalat}
+                      koulutustyypit={_props.koulutustyypit}
+                      lisatiedot={_props.lisatiedot}
+                      maaraystyypit={_props.maaraystyypit}
+                      muut={_props.muut}
+                      opetuskielet={_props.opetuskielet}
+                      organisaatio={_props.organisaatio}
+                      viimeisinLupa={_props.viimeisinLupa}
+                    />
                   </MuutoksetContainer>
                 )}
               />
@@ -73,11 +84,24 @@ const Esittelijat = ({
                 <BaseData
                   locale={locale}
                   koulutustyyppi={koulutusmuoto.koulutustyyppi}
-                  render={_props => (
-                    <MuutoksetContainer scope={scope}>
-                      <AsiaDialogContainer {..._props} />
-                    </MuutoksetContainer>
-                  )}
+                  render={_props => {
+                    return (
+                      <MuutoksetContainer scope={scope}>
+                        <AsiaDialogContainer
+                          kohteet={_props.kohteet}
+                          koulutukset={_props.koulutukset}
+                          koulutusalat={_props.koulutusalat}
+                          koulutustyypit={_props.koulutustyypit}
+                          lisatiedot={_props.lisatiedot}
+                          maaraystyypit={_props.maaraystyypit}
+                          muut={_props.muut}
+                          opetuskielet={_props.opetuskielet}
+                          organisaatio={_props.organisaatio}
+                          viimeisinLupa={_props.viimeisinLupa}
+                        />
+                      </MuutoksetContainer>
+                    );
+                  }}
                 />
               );
             }}
@@ -89,3 +113,18 @@ const Esittelijat = ({
 };
 
 export default Esittelijat;
+
+// kohteet,
+// koulutukset,
+// koulutusalat,
+// koulutustyypit,
+// maaraystyypit,
+// muut,
+// opetuskielet,
+
+// kielet,
+// kunnat,
+// lisatiedot,
+// maakunnat,
+// maakuntakunnat,
+// tutkinnot,

--- a/src/css/tailwind.src.pcss
+++ b/src/css/tailwind.src.pcss
@@ -27,6 +27,10 @@ div.MuiDialogContent-root {
   padding: 0;
 }
 
+form .MuiTypography-h2 {
+  @apply pt-16;
+}
+
 /* User research indicates that number input controls need to go (CSCOIVA-1315) */
 /* Chrome and others */
 input::-webkit-outer-spin-button,

--- a/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
+++ b/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
@@ -31,7 +31,8 @@ export async function createObjectToSave(
   kohteet,
   maaraystyypit,
   muut,
-  lupaKohteet
+  lupaKohteet,
+  lomakedata
 ) {
   // TUTKINNOT, OSAAMISALAT JA TUKINTOKIELET
   const tutkinnot = await tutkinnotHelper.defineBackendChangeObjects(
@@ -107,7 +108,8 @@ export async function createObjectToSave(
     maaraystyypit,
     muut,
     lupaKohteet,
-    changeObjects.muut
+    changeObjects.muut,
+    lomakedata.muut
   );
 
   // MUUT
@@ -167,8 +169,6 @@ export async function createObjectToSave(
     : "";
   // This helps the frontend to initialize the first three fields on form load.
   objectToSave.meta.topthree = changeObjects.topthree;
-
-  console.info(objectToSave);
 
   return objectToSave;
 }

--- a/src/helpers/kunnat/index.js
+++ b/src/helpers/kunnat/index.js
@@ -1,17 +1,20 @@
-import { mapObjIndexed, head, groupBy, prop, omit } from "ramda";
+import { mapObjIndexed, head, groupBy, prop, omit, find, propEq } from "ramda";
 import localforage from "localforage";
 
-export function initializeKunta(kuntadata) {
+export function initializeKunta(kuntadata, ahvenanmaanKunnat = []) {
   const currentDate = new Date();
   if (
     currentDate >= new Date(kuntadata.voimassaAlkuPvm) &&
-    currentDate <= new Date(kuntadata.voimassaLoppuPvm || currentDate)
+    currentDate <= new Date(kuntadata.voimassaLoppuPvm || currentDate) &&
+    // Ahvenanmaata kuntineen ei tarvita tässä sovelluksessa
+    !find(propEq("koodiarvo", kuntadata.koodiArvo), ahvenanmaanKunnat)
   ) {
-    return omit(["koodiArvo"], {
+    const kunta = omit(["koodiArvo"], {
       ...kuntadata,
       koodiarvo: kuntadata.koodiArvo,
       metadata: mapObjIndexed(head, groupBy(prop("kieli"), kuntadata.metadata))
     });
+    return kunta;
   }
   return null;
 }

--- a/src/helpers/maakunnat/index.js
+++ b/src/helpers/maakunnat/index.js
@@ -15,7 +15,11 @@ export function initializeMaakunta(maakuntadata, localeUpper) {
   const currentDate = new Date();
   if (
     currentDate >= new Date(maakuntadata.voimassaAlkuPvm) &&
-    currentDate <= new Date(maakuntadata.voimassaLoppuPvm || currentDate)
+    currentDate <= new Date(maakuntadata.voimassaLoppuPvm || currentDate) &&
+    // 21 = Ahvenanmaa
+    maakuntadata.koodiArvo !== "21" &&
+    // 99 = Ei tiedossa
+    maakuntadata.koodiArvo !== "99"
   ) {
     // Filter out ulkomaat
     const kunnat = filter(
@@ -47,6 +51,10 @@ export function initializeMaakunta(maakuntadata, localeUpper) {
     });
   }
   return null;
+}
+
+export async function getMaakunnat() {
+  return await localforage.getItem("maakunnat");
 }
 
 export async function getMaakuntakunnat() {

--- a/src/helpers/opetustaAntavatKunnat/index.js
+++ b/src/helpers/opetustaAntavatKunnat/index.js
@@ -48,7 +48,7 @@ export async function defineBackendChangeObjects(
    * Noudetaan toiminta-alueeseen liittyvät määräykset. Määräysten uuid-arvoja
    * tarvitaan lupaan kuuluvien alueiden poistamisen yhteydessä.
    */
-  const maaraykset = getMaarayksetByTunniste("toimintaalue", lupaMaaraykset);
+  const maaraykset = await getMaarayksetByTunniste("toimintaalue", lupaMaaraykset);
   const maakuntakunnat = await getMaakuntakunnat();
 
   /**

--- a/src/helpers/toiminta-alue/index.js
+++ b/src/helpers/toiminta-alue/index.js
@@ -46,7 +46,7 @@ export async function defineBackendChangeObjects(
    * Noudetaan toiminta-alueeseen liittyvät määräykset. Määräysten uuid-arvoja
    * tarvitaan lupaan kuuluvien alueiden poistamisen yhteydessä.
    */
-  const maaraykset = getMaarayksetByTunniste("toimintaalue", lupaMaaraykset);
+  const maaraykset = await getMaarayksetByTunniste("toimintaalue", lupaMaaraykset);
   const maakuntakunnat = await getMaakuntakunnat();
 
   /**
@@ -128,7 +128,7 @@ export async function defineBackendChangeObjects(
   }, maakuntakunnat);
 
   // YKSITTÄISTEN MAAKUNTIEN JA KUNTIEN POISTAMINEN
-  const yksittäisetMaaraykset = filter(
+  const yksittaisetMaaraykset = filter(
     compose(not, propEq("koodisto", "nuts1")),
     maaraykset
   );
@@ -193,7 +193,7 @@ export async function defineBackendChangeObjects(
       };
     }
     return null;
-  }, yksittäisetMaaraykset).filter(Boolean);
+  }, yksittaisetMaaraykset).filter(Boolean);
 
   /**
    * YKSITTÄISTEN MAAKUNTIEN JA KUNTIEN LISÄÄMINEN

--- a/src/index.js
+++ b/src/index.js
@@ -40,9 +40,7 @@ theme.typography.h1 = {
   paddingTop: "1rem",
   [theme.breakpoints.down("xs")]: {
     fontSize: "1.875rem"
-  },
-  paddingBottom: "1rem",
-  paddingTop: "1rem"
+  }
 };
 
 theme.typography.h2 = {
@@ -53,9 +51,7 @@ theme.typography.h2 = {
   paddingTop: "1rem",
   [theme.breakpoints.down("xs")]: {
     fontSize: "1.375rem"
-  },
-  paddingBottom: "1rem",
-  paddingTop: "1rem"
+  }
 };
 
 theme.typography.h3 = {

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/AsiaDialogContainer.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/AsiaDialogContainer.js
@@ -16,19 +16,14 @@ import { getSavedChangeObjects } from "helpers/ammatillinenKoulutus/commonUtils"
  * @param {Object} props.intl - Object of react-intl library.
  */
 const AsiaDialogContainer = ({
-  kielet,
   kohteet,
   koulutukset,
   koulutusalat,
   koulutustyypit,
-  kunnat,
-  maakunnat,
-  maakuntakunnat,
   maaraystyypit,
   muut,
   opetuskielet,
   organisaatio,
-  tutkinnot,
   viimeisinLupa
 }) => {
   const intl = useIntl();
@@ -74,22 +69,16 @@ const AsiaDialogContainer = ({
   return muutospyynto ? (
     <UusiAsiaDialog
       history={history}
-      kielet={kielet}
       kohteet={kohteet}
       koulutukset={koulutukset}
       koulutusalat={koulutusalat}
       koulutustyypit={koulutustyypit}
-      kunnat={kunnat}
       lupa={viimeisinLupa}
       lupaKohteet={lupaKohteet}
-      maakunnat={maakunnat}
-      maakuntakunnat={maakuntakunnat}
       maaraystyypit={maaraystyypit}
       muut={muut}
-      onNewDocSave={() => {}}
       opetuskielet={opetuskielet}
       organisation={organisaatio}
-      tutkinnot={tutkinnot}
     />
   ) : (
     <Loading />

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/02-VaativaTuki/index.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/02-VaativaTuki/index.js
@@ -35,10 +35,7 @@ const VaativaTuki = ({
 
   const dataLomakepalvelulle = useMemo(
     () => ({
-      isApplyForValueSet: prop(
-        "isApplyForValueSet",
-        lomakedata.vaativaTuki || {}
-      ),
+      isApplyForValueSet: prop("isApplyForValueSet", lomakedata.vaativaTuki),
       items,
       maarayksetByKoodiarvo,
       koodiarvot: ["2", "16", "17", "18", "19", "20", "21"]

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/03-Sisaoppilaitos/index.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/Osiot/Muut/03-Sisaoppilaitos/index.js
@@ -35,10 +35,7 @@ const Sisaoppilaitos = ({
 
   const dataLomakepalvelulle = useMemo(
     () => ({
-      isApplyForValueSet: prop(
-        "isApplyForValueSet",
-        lomakedata.sisaoppilaitos || {}
-      ),
+      isApplyForValueSet: prop("isApplyForValueSet", lomakedata.sisaoppilaitos),
       items,
       koodiarvot: ["4"],
       maarayksetByKoodiarvo
@@ -65,13 +62,6 @@ const Sisaoppilaitos = ({
       const koodiarvo = path(
         ["properties", "metadata", "koodiarvo"],
         changeObj
-      );
-
-      console.info(
-        koodiarvo,
-        typeof koodiarvo,
-        koodiarvot,
-        includes(koodiarvo, koodiarvot)
       );
 
       return includes(koodiarvo, koodiarvot) &&

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/index.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Esittelijat/Lupanakyma/index.js
@@ -6,20 +6,15 @@ import { useValidity } from "stores/lomakedata";
 import { Typography } from "@material-ui/core";
 
 const Lupanakyma = ({
-  kielet,
   kohteet,
   koulutukset,
   koulutusalat,
   koulutustyypit,
-  kunnat,
   maaraykset,
   lupaKohteet,
-  maakunnat,
-  maakuntakunnat,
   maaraystyypit,
   muut,
-  organisation,
-  tutkinnot
+  organisation
 }) => {
   const intl = useIntl();
   const [validity] = useValidity();
@@ -86,19 +81,14 @@ const Lupanakyma = ({
         id="wizard-content"
         className="px-16 xl:w-3/4 max-w-7xl m-auto mb-20">
         <EsittelijatMuutospyynto
-          kielet={kielet}
           kohteet={kohteet}
           koulutukset={koulutukset}
           koulutusalat={koulutusalat}
           koulutustyypit={koulutustyypit}
-          kunnat={kunnat}
-          maakuntakunnat={maakuntakunnat}
-          maakunnat={maakunnat}
           maaraykset={maaraykset}
           lupaKohteet={lupaKohteet}
           maaraystyypit={maaraystyypit}
           muut={muut}
-          tutkinnot={tutkinnot}
         />
       </div>
     </div>

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
@@ -22,21 +22,16 @@ const constants = {
 };
 
 const defaultProps = {
-  kielet: [],
   kohteet: [],
   koulutukset: {},
   koulutusalat: [],
   koulutustyypit: [],
-  kunnat: [],
-  maakuntakunnat: [],
-  maakunnat: [],
   maaraykset: [],
   lupaKohteet: {},
   maaraystyypit: [],
   muut: [],
   opetuskielet: [],
-  opiskelijavuodet: [],
-  tutkinnot: []
+  opiskelijavuodet: []
 };
 
 const EsittelijatMuutospyynto = ({
@@ -44,16 +39,11 @@ const EsittelijatMuutospyynto = ({
   koulutukset = defaultProps.koulutukset,
   koulutusalat = defaultProps.koulutusalat,
   koulutustyypit = defaultProps.koulutustyypit,
-  kunnat = defaultProps.kunnat,
-  maakuntakunnat = defaultProps.maakuntakunnat,
-  maakunnat = defaultProps.maakunnat,
   maaraykset = defaultProps.maaraykset,
   lupaKohteet = defaultProps.lupaKohteet,
   maaraystyypit: maaraystyypitRaw = defaultProps.maaraystyypit,
   muut = defaultProps.muut,
   opiskelijavuodet = defaultProps.opiskelijavuodet,
-  tutkinnot = defaultProps.tutkinnot,
-
   // Callback methods
   handleSubmit
 }) => {
@@ -149,7 +139,6 @@ const EsittelijatMuutospyynto = ({
           koulutusalat={koulutusalat}
           koulutustyypit={koulutustyypit}
           title={sectionHeadings.tutkinnotJaKoulutukset.title}
-          tutkinnot={tutkinnot}
         />
 
         <Typography component="h4" variant="h4">
@@ -173,14 +162,11 @@ const EsittelijatMuutospyynto = ({
           showCategoryTitles={true}
         />
 
-        <Tutkintokielet koulutusalat={koulutusalat} tutkinnot={tutkinnot} />
+        <Tutkintokielet koulutusalat={koulutusalat} />
 
         <MuutospyyntoWizardToimintaalue
           code={String(sectionHeadings.toimintaalue.number)}
           lupakohde={lupaKohteet[3]}
-          kunnat={kunnat}
-          maakuntakunnat={maakuntakunnat}
-          maakunnat={maakunnat}
           sectionId={"toimintaalue"}
           title={sectionHeadings.toimintaalue.title}
           valtakunnallinenMaarays={valtakunnallinenMaarays}
@@ -213,20 +199,15 @@ const EsittelijatMuutospyynto = ({
 };
 
 EsittelijatMuutospyynto.propTypes = {
-  kielet: PropTypes.array,
   kohteet: PropTypes.array,
   koulutukset: PropTypes.object,
   koulutusalat: PropTypes.array,
   koulutustyypit: PropTypes.array,
-  kunnat: PropTypes.array,
-  maakuntakunnat: PropTypes.array,
   maaraykset: PropTypes.array,
-  maakunnat: PropTypes.array,
   lupaKohteet: PropTypes.object,
   maaraystyypit: PropTypes.array,
   muut: PropTypes.array,
-  opiskelijavuodet: PropTypes.array,
-  tutkinnot: PropTypes.array
+  opiskelijavuodet: PropTypes.array
 };
 
 export default EsittelijatMuutospyynto;

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/EsittelijatMuutospyynto.js
@@ -14,6 +14,7 @@ import Lomake from "components/02-organisms/Lomake";
 import * as R from "ramda";
 import Tutkintokielet from "scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Kielet/Tutkintokielet";
 import { Typography } from "@material-ui/core";
+import FormTitle from "components/00-atoms/FormTitle";
 
 const constants = {
   formLocation: {
@@ -133,6 +134,11 @@ const EsittelijatMuutospyynto = ({
         <Typography component="h2" variant="h2">
           {intl.formatMessage(common.changesText)}
         </Typography>
+
+        <FormTitle
+          code={sectionHeadings.tutkinnotJaKoulutukset.number}
+          title={sectionHeadings.tutkinnotJaKoulutukset.title}
+        />
 
         <Tutkinnot
           code={sectionHeadings.tutkinnotJaKoulutukset.number}

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Muu.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Muu.js
@@ -17,7 +17,6 @@ const Muu = ({ configObj, koodiarvotLuvassa, sectionId }) => {
   const [, { setLomakedata }] = useLomakedata({ anchor: "muut" });
 
   useEffect(() => {
-    console.info(configObj);
     const muutostenJalkeenAktiivisetKoodiarvot = filter(koodiarvo => {
       const changeObj = find(
         pathEq(["properties", "metadata", "koodiarvo"], koodiarvo),

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizard.js
@@ -512,7 +512,6 @@ const MuutospyyntoWizard = ({
                     onChangesRemove={onChangesRemove}
                     onChangesUpdate={onChangeObjectsUpdate}
                     opetuskielet={opetuskielet}
-                    tutkinnot={tutkinnot}
                   />
                 </WizardPage>
               )}

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuut.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuut.js
@@ -18,132 +18,134 @@ const defaultProps = {
   muut: []
 };
 
-const MuutospyyntoWizardMuut = ({
-  code,
-  maaraykset = defaultProps.maaraykset,
-  muut = defaultProps.muut,
-  sectionId,
-  title
-}) => {
-  const intl = useIntl();
-  const localeUpper = toUpper(intl.locale);
+const MuutospyyntoWizardMuut = React.memo(
+  ({
+    code,
+    maaraykset = defaultProps.maaraykset,
+    muut = defaultProps.muut,
+    sectionId,
+    title
+  }) => {
+    const intl = useIntl();
+    const localeUpper = toUpper(intl.locale);
 
-  const maarayksetByKoodiarvo = useMemo(
-    () =>
-      groupBy(
-        prop("koodiarvo"),
-        filter(
-          propEq("koodisto", "oivamuutoikeudetvelvollisuudetehdotjatehtavat"),
-          maaraykset
-        )
-      ),
-    [maaraykset]
-  );
-
-  const items = useMemo(() => {
-    const group = omit(
-      [undefined],
-      groupBy(item => {
-        const kasite = path(["metadata", localeUpper, "kasite"], item);
-        if (item.koodiarvo === "9") {
-          return "selvitykset";
-        } else {
-          return kasite;
-        }
-      }, muut)
+    const maarayksetByKoodiarvo = useMemo(
+      () =>
+        groupBy(
+          prop("koodiarvo"),
+          filter(
+            propEq("koodisto", "oivamuutoikeudetvelvollisuudetehdotjatehtavat"),
+            maaraykset
+          )
+        ),
+      [maaraykset]
     );
-    return group;
-  }, [localeUpper, muut]);
 
-  const vaativaTukiItems = useMemo(
-    () => ({
-      vaativa_1: items.vaativa_1,
-      vaativa_2: items.vaativa_2
-    }),
-    [items]
-  );
+    const items = useMemo(() => {
+      const group = omit(
+        [undefined],
+        groupBy(item => {
+          const kasite = path(["metadata", localeUpper, "kasite"], item);
+          if (item.koodiarvo === "9") {
+            return "selvitykset";
+          } else {
+            return kasite;
+          }
+        }, muut)
+      );
+      return group;
+    }, [localeUpper, muut]);
 
-  return (
-    <React.Fragment>
-      <Typography component="h2" variant="h2">
-        {code ? `${code}. ` : ""}
-        {title}
-      </Typography>
-      {!!items.laajennettu && items.laajennettu.length > 0 ? (
-        <Laajennettu
-          items={items.laajennettu}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_01`}></Laajennettu>
-      ) : null}
+    const vaativaTukiItems = useMemo(
+      () => ({
+        vaativa_1: items.vaativa_1,
+        vaativa_2: items.vaativa_2
+      }),
+      [items]
+    );
 
-      {(!!items.vaativa_1 && items.vaativa_1.length > 0) ||
-      (!!items.vaativa_2 && items.vaativa_2.length > 0) ? (
-        <VaativaTuki
-          items={vaativaTukiItems}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_02`}></VaativaTuki>
-      ) : null}
+    return (
+      <React.Fragment>
+        <Typography component="h2" variant="h2">
+          {code ? `${code}. ` : ""}
+          {title}
+        </Typography>
+        {!!items.laajennettu && items.laajennettu.length > 0 ? (
+          <Laajennettu
+            items={items.laajennettu}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_01`}></Laajennettu>
+        ) : null}
 
-      {!!items.sisaoppilaitos && items.sisaoppilaitos.length > 0 ? (
-        <Sisaoppilaitos
-          items={items.sisaoppilaitos}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_03`}></Sisaoppilaitos>
-      ) : null}
+        {(!!items.vaativa_1 && items.vaativa_1.length > 0) ||
+        (!!items.vaativa_2 && items.vaativa_2.length > 0) ? (
+          <VaativaTuki
+            items={vaativaTukiItems}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_02`}></VaativaTuki>
+        ) : null}
 
-      {!!items.vankila && items.vankila.length > 0 ? (
-        <Vankila
-          items={items.vankila}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_04`}></Vankila>
-      ) : null}
+        {!!items.sisaoppilaitos && items.sisaoppilaitos.length > 0 ? (
+          <Sisaoppilaitos
+            items={items.sisaoppilaitos}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_03`}></Sisaoppilaitos>
+        ) : null}
 
-      {!!items.urheilu && items.urheilu.length > 0 ? (
-        <Urheilu
-          items={items.urheilu}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_05`}></Urheilu>
-      ) : null}
+        {!!items.vankila && items.vankila.length > 0 ? (
+          <Vankila
+            items={items.vankila}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_04`}></Vankila>
+        ) : null}
 
-      {!!items.yhteistyo && items.yhteistyo.length > 0 ? (
-        <Yhteistyo
-          items={items.yhteistyo}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_06`}></Yhteistyo>
-      ) : null}
+        {!!items.urheilu && items.urheilu.length > 0 ? (
+          <Urheilu
+            items={items.urheilu}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_05`}></Urheilu>
+        ) : null}
 
-      {!!items.yhteistyosopimus && items.yhteistyosopimus.length > 0 ? (
-        <Yhteistyosopimus
-          items={items.yhteistyosopimus}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_08`}></Yhteistyosopimus>
-      ) : null}
+        {!!items.yhteistyo && items.yhteistyo.length > 0 ? (
+          <Yhteistyo
+            items={items.yhteistyo}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_06`}></Yhteistyo>
+        ) : null}
 
-      {!!items.selvitykset && items.selvitykset.length > 0 ? (
-        <Selvitykset
-          items={items.selvitykset}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_09`}></Selvitykset>
-      ) : null}
+        {!!items.yhteistyosopimus && items.yhteistyosopimus.length > 0 ? (
+          <Yhteistyosopimus
+            items={items.yhteistyosopimus}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_08`}></Yhteistyosopimus>
+        ) : null}
 
-      {!!items.muumaarays && items.muumaarays.length > 0 ? (
-        <MuuMaarays
-          items={items.muumaarays}
-          localeUpper={localeUpper}
-          maarayksetByKoodiarvo={maarayksetByKoodiarvo}
-          sectionId={`${sectionId}_07`}></MuuMaarays>
-      ) : null}
-    </React.Fragment>
-  );
-};
+        {!!items.selvitykset && items.selvitykset.length > 0 ? (
+          <Selvitykset
+            items={items.selvitykset}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_09`}></Selvitykset>
+        ) : null}
+
+        {!!items.muumaarays && items.muumaarays.length > 0 ? (
+          <MuuMaarays
+            items={items.muumaarays}
+            localeUpper={localeUpper}
+            maarayksetByKoodiarvo={maarayksetByKoodiarvo}
+            sectionId={`${sectionId}_07`}></MuuMaarays>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+);
 
 MuutospyyntoWizardMuut.propTypes = {
   headingNumber: PropTypes.number,

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardMuutokset.js
@@ -73,7 +73,6 @@ const MuutospyyntoWizardMuutokset = React.memo(
               koulutustyypit={props.koulutustyypit}
               onChangesRemove={onChangesRemove}
               onChangesUpdate={onChangesUpdate}
-              tutkinnot={props.tutkinnot}
             />
             <Typography component="h4" variant="h4">
               {intl.formatMessage(common.koulutukset)}
@@ -114,9 +113,6 @@ const MuutospyyntoWizardMuutokset = React.memo(
             <MuutospyyntoWizardToimintaalue
               changeObjects={props.changeObjects}
               lupakohde={props.lupaKohteet[3]}
-              kunnat={props.kunnat}
-              maakuntakunnat={props.maakuntakunnat}
-              maakunnat={props.maakunnat}
               onChangesRemove={onChangesRemove}
               onChangesUpdate={onChangesUpdate}
               sectionId={"toimintaalue"}
@@ -177,9 +173,6 @@ MuutospyyntoWizardMuutokset.propTypes = {
   kielet: PropTypes.array,
   kohteet: PropTypes.array,
   koulutukset: PropTypes.object,
-  kunnat: PropTypes.array,
-  maakuntakunnat: PropTypes.array,
-  maakunnat: PropTypes.array,
   lupa: PropTypes.object,
   lupaKohteet: PropTypes.object,
   maaraystyypit: PropTypes.array,

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardOpiskelijavuodet.js
@@ -134,7 +134,7 @@ const MuutospyyntoWizardOpiskelijavuodet = React.memo(
       <Lomake
         anchor={sectionId}
         code={code}
-        data={lomakedata}
+        data={{ lomakedata: { ...lomakedata, sectionId }, muutLomakedata }}
         formTitle={title}
         isRowExpanded={true}
         mode="modification"

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardToimintaalue.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/MuutospyyntoWizardToimintaalue.js
@@ -256,11 +256,11 @@ const MuutospyyntoWizardToimintaalue = React.memo(props => {
   const kunnatWithoutAhvenanmaan = useMemo(() => {
     return R.filter(kunta => {
       const result = R.find(
-        R.propEq("kuntaKoodiarvo", kunta.koodiArvo),
+        R.propEq("kuntaKoodiarvo", kunta.koodiarvo),
         kuntaProvinceMapping
       );
       return (
-        result && result.maakuntaKey !== "FI-01" && kunta.koodiArvo !== "200" // 200 Ulkomaa
+        result && result.maakuntaKey !== "FI-01" && kunta.koodiarvo !== "200" // 200 Ulkomaa
       );
     }, props.kunnat);
   }, [props.kunnat]);
@@ -268,7 +268,7 @@ const MuutospyyntoWizardToimintaalue = React.memo(props => {
   const provincesWithoutAhvenanmaa = useMemo(() => {
     return R.filter(maakunta => {
       // 21 = Ahvenanmaa
-      return maakunta.koodiArvo !== "21";
+      return maakunta.koodiarvo !== "21";
     }, props.maakunnat);
   }, [props.maakunnat]);
 

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Tutkinnot/Koulutusala.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Tutkinnot/Koulutusala.js
@@ -28,6 +28,7 @@ const Koulutusala = ({ data, sectionId, title, tutkinnot }) => {
     <Lomake
       anchor={sectionId}
       data={data}
+      key={sectionId}
       mode="modification"
       path={constants.formLocation}
       rowTitle={title}

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Tutkinnot/index.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/Jarjestajat/Jarjestaja/Hakemukset/Muutospyynto/components/Tutkinnot/index.js
@@ -1,15 +1,24 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { toUpper, map, groupBy, prop } from "ramda";
 import Koulutusala from "./Koulutusala";
 import { Typography } from "@material-ui/core";
+import { getTutkinnotFromStorage } from "helpers/tutkinnot";
 import common from "i18n/definitions/common";
 
-const Tutkinnot = ({ koulutusalat, koulutustyypit, tutkinnot }) => {
+const Tutkinnot = React.memo(({ koulutusalat, koulutustyypit }) => {
   const intl = useIntl();
   const sectionId = "tutkinnot";
   const localeUpper = toUpper(intl.locale);
+  const [tutkinnot, setTutkinnot] = useState([]);
+
+  useEffect(() => {
+    getTutkinnotFromStorage().then(tutkinnot => {
+      setTutkinnot(tutkinnot);
+    });
+  }, []);
+
   const tutkinnotByKoulutusala = groupBy(
     prop("koulutusalakoodiarvo"),
     tutkinnot
@@ -48,12 +57,11 @@ const Tutkinnot = ({ koulutusalat, koulutustyypit, tutkinnot }) => {
       }, koulutusalat)}
     </React.Fragment>
   );
-};
+});
 
 Tutkinnot.propTypes = {
   koulutusalat: PropTypes.array,
-  koulutustyypit: PropTypes.array,
-  tutkinnot: PropTypes.array
+  koulutustyypit: PropTypes.array
 };
 
 export default Tutkinnot;

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/LupaSection.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/JarjestamislupaHTML/LupaSection.js
@@ -188,7 +188,6 @@ const LupaSection = props => {
         const { kohdeKuvaus, kohdeArvot, tutkintokieletArr } = kohde;
 
         tutkintokieletArr.forEach(tutkintokieli => {
-          console.info(tutkintokieli);
           tutkintokieli.kieli = parseLocalizedField(
             (find(k => k.koodiarvo === tutkintokieli.kieli, kielet) || {})
               .metadata,

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/UusiAsiaDialog.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/UusiAsiaDialog.js
@@ -23,6 +23,8 @@ import {
 import Lupanakyma from "./Esittelijat/Lupanakyma/index";
 import { createObjectToSave } from "helpers/ammatillinenKoulutus/tallentaminen/esittelijat";
 import { getSavedChangeObjects } from "helpers/ammatillinenKoulutus/commonUtils";
+import equal from "react-fast-compare";
+import { useAllSections } from "stores/lomakedata";
 
 const isDebugOn = process.env.REACT_APP_DEBUG === "true";
 
@@ -58,7 +60,6 @@ const FormDialog = withStyles(() => ({
 });
 
 const defaultProps = {
-  kielet: [],
   kohteet: [],
   koulutukset: {
     muut: {},
@@ -66,35 +67,26 @@ const defaultProps = {
   },
   koulutusalat: {},
   koulutustyypit: {},
-  kunnat: [],
   lupa: {},
   lupaKohteet: {},
-  maakunnat: [],
-  maakuntakunnat: [],
   maaraystyypit: [],
   muut: [],
   opetuskielet: [],
-  organisation: {},
-  tutkinnot: []
+  organisation: {}
 };
 
 const UusiAsiaDialog = React.memo(
   ({
-    kielet = defaultProps.kielet,
     kohteet = defaultProps.kohteet,
     koulutukset = defaultProps.koulutukset,
     koulutusalat = defaultProps.koulutusalat,
     koulutustyypit = defaultProps.koulutustyypit,
-    kunnat = defaultProps.kunnat,
     lupa = defaultProps.lupa,
     lupaKohteet = defaultProps.lupaKohteet,
-    maakunnat = defaultProps.maakunnat,
-    maakuntakunnat = defaultProps.maakuntakunnat,
     maaraystyypit = defaultProps.maaraystyypit,
     muut = defaultProps.muut,
     onNewDocSave,
-    organisation = defaultProps.organisation,
-    tutkinnot = defaultProps.tutkinnot
+    organisation = defaultProps.organisation
   }) => {
     const intl = useIntl();
     const params = useParams();
@@ -107,6 +99,7 @@ const UusiAsiaDialog = React.memo(
     const [unsavedChangeObjects] = useUnsavedChangeObjects();
     const [underRemovalChangeObjects] = useUnderRemovalChangeObjects();
     const [, muutospyyntoActions] = useMuutospyynto();
+    const [lomakedata] = useAllSections();
 
     // Relevantit muutosobjektit osioittain (tarvitaan tallennettaessa)
     const [topThreeCO] = useChangeObjectsByAnchorWithoutUnderRemoval({
@@ -243,7 +236,7 @@ const UusiAsiaDialog = React.memo(
             maaraystyypit,
             muut,
             lupaKohteet,
-            "ESITTELIJA"
+            lomakedata
           )
         );
 
@@ -256,7 +249,7 @@ const UusiAsiaDialog = React.memo(
         }
 
         if (!!muutospyynto && R.prop("uuid", muutospyynto)) {
-          if (!uuid && !fromDialog) {
+          if (!uuid && !fromDialog && !!onNewDocSave) {
             // Jos kyseessä on ensimmäinen tallennus...
             onNewDocSave(muutospyynto.uuid);
           } else {
@@ -276,6 +269,7 @@ const UusiAsiaDialog = React.memo(
         initializeChanges,
         intl.locale,
         koulutuksetCO,
+        lomakedata,
         lupa,
         lupaKohteet,
         maaraystyypit,
@@ -328,21 +322,16 @@ const UusiAsiaDialog = React.memo(
                 {!R.isEmpty(organisation) ? (
                   <Lupanakyma
                     history={history}
-                    kielet={kielet}
                     kohteet={kohteet}
                     koulutukset={koulutukset}
                     koulutusalat={koulutusalat}
                     koulutustyypit={koulutustyypit}
-                    kunnat={kunnat}
                     maaraykset={lupa.maaraykset}
                     lupaKohteet={lupaKohteet}
-                    maakunnat={maakunnat}
-                    maakuntakunnat={maakuntakunnat}
                     maaraystyypit={maaraystyypit}
                     muut={muut}
                     onNewDocSave={onNewDocSave}
                     organisation={organisation}
-                    tutkinnot={tutkinnot}
                   />
                 ) : null}
               </div>
@@ -381,26 +370,24 @@ const UusiAsiaDialog = React.memo(
         </div>
       )
     );
+  },
+  (cp, np) => {
+    return equal(cp, np);
   }
 );
 
 UusiAsiaDialog.propTypes = {
   history: PropTypes.object,
-  kielet: PropTypes.array,
   koulutusalat: PropTypes.array,
   koulutustyypit: PropTypes.array,
-  kunnat: PropTypes.array,
   lupa: PropTypes.object,
   lupaKohteet: PropTypes.object,
-  maakunnat: PropTypes.array,
-  maakuntakunnat: PropTypes.array,
   maaraystyypit: PropTypes.array,
   muut: PropTypes.array,
   onChangeObjectsUpdate: PropTypes.func,
   onNewDocSave: PropTypes.func,
   opetuskielet: PropTypes.array,
-  organisation: PropTypes.object,
-  tutkinnot: PropTypes.array
+  organisation: PropTypes.object
 };
 
 export default UusiAsiaDialog;

--- a/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/UusiAsiaDialogContainer.js
+++ b/src/scenes/Koulutusmuodot/AmmatillinenKoulutus/UusiAsiaDialogContainer.js
@@ -12,19 +12,14 @@ import { isEmpty } from "ramda";
  * @param {Object} props.intl - Object of react-intl library.
  */
 const UusiAsiaDialogContainer = ({
-  kielet,
   kohteet,
   koulutukset,
   koulutusalat,
   koulutustyypit,
-  kunnat,
-  maakunnat,
-  maakuntakunnat,
   maaraystyypit,
   muut,
   opetuskielet,
   organisaatio,
-  tutkinnot,
   viimeisinLupa
 }) => {
   const intl = useIntl();
@@ -56,22 +51,17 @@ const UusiAsiaDialogContainer = ({
   return (
     <UusiAsiaDialog
       history={history}
-      kielet={kielet}
       kohteet={kohteet}
       koulutukset={koulutukset}
       koulutusalat={koulutusalat}
       koulutustyypit={koulutustyypit}
-      kunnat={kunnat}
       lupa={viimeisinLupa}
       lupaKohteet={lupaKohteet}
-      maakunnat={maakunnat}
-      maakuntakunnat={maakuntakunnat}
       maaraystyypit={maaraystyypit}
       muut={muut}
       onNewDocSave={onNewDocSave}
       opetuskielet={opetuskielet}
       organisation={organisaatio}
-      tutkinnot={tutkinnot}
     />
   );
 };

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/AsiaDialogContainer.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/AsiaDialogContainer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import Loading from "modules/Loading";
 import UusiAsiaDialog from "./Dialogit/Esittelijat/Lupanakyma/index";
-import { useHistory, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { parseLupa } from "utils/lupaParser";
 import { API_BASE_URL } from "modules/constants";
 import { backendRoutes } from "stores/utils/backendRoutes";
@@ -16,25 +16,15 @@ import { useChangeObjects } from "stores/muutokset";
  * @param {Object} props.intl - Object of react-intl library.
  */
 const AsiaDialogContainer = ({
-  kielet,
   kohteet,
-  koulutukset,
   koulutusalat,
   koulutustyypit,
-  kunnat,
   lisatiedot,
-  maakunnat,
-  maakuntakunnat,
   maaraystyypit,
-  muut,
-  opetuskielet,
-  opetustehtavakoodisto,
   organisaatio,
-  tutkinnot,
   viimeisinLupa
 }) => {
   const intl = useIntl();
-  let history = useHistory();
   const { uuid } = useParams();
   const [, { initializeChanges }] = useChangeObjects();
   const [muutospyynto, setMuutospyynto] = useState();
@@ -60,7 +50,7 @@ const AsiaDialogContainer = ({
     }
   }, [muutospyynto, uuid]);
 
-  const lupaKohteet = useMemo(() => {
+  const lupakohteet = useMemo(() => {
     const result = viimeisinLupa
       ? parseLupa(
           { ...viimeisinLupa },
@@ -73,25 +63,14 @@ const AsiaDialogContainer = ({
 
   return muutospyynto ? (
     <UusiAsiaDialog
-      history={history}
-      kielet={kielet}
       kohteet={kohteet}
-      koulutukset={koulutukset}
       koulutusalat={koulutusalat}
       koulutustyypit={koulutustyypit}
-      kunnat={kunnat}
       lisatiedot={lisatiedot}
       lupa={viimeisinLupa}
-      lupaKohteet={lupaKohteet}
-      maakunnat={maakunnat}
-      maakuntakunnat={maakuntakunnat}
+      lupakohteet={lupakohteet}
       maaraystyypit={maaraystyypit}
-      muut={muut}
-      onNewDocSave={() => {}}
-      opetuskielet={opetuskielet}
-      opetustehtavakoodisto={opetustehtavakoodisto}
       organisation={organisaatio}
-      tutkinnot={tutkinnot}
     />
   ) : (
     <Loading />

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/Dialogit/Esittelijat/Lupanakyma/LupanakymaDialogContainer.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/Dialogit/Esittelijat/Lupanakyma/LupanakymaDialogContainer.js
@@ -12,30 +12,13 @@ import { isEmpty } from "ramda";
  * @param {Object} props.intl - Object of react-intl library.
  */
 const UusiAsiaDialogContainer = React.memo(
-  ({
-    kielet,
-    kohteet,
-    koulutukset,
-    koulutusalat,
-    koulutustyypit,
-    kunnat,
-    lisatiedot,
-    maakunnat,
-    maakuntakunnat,
-    maaraystyypit,
-    muut,
-    opetuskielet,
-    opetustehtavakoodisto,
-    organisaatio,
-    tutkinnot,
-    viimeisinLupa
-  }) => {
+  ({ kohteet, lisatiedot, maaraystyypit, organisaatio, viimeisinLupa }) => {
+    const history = useHistory();
     const intl = useIntl();
 
     let { id } = useParams();
-    let history = useHistory();
 
-    const lupaKohteet = useMemo(() => {
+    const lupakohteet = useMemo(() => {
       const result = !isEmpty(viimeisinLupa)
         ? parseLupa(
             { ...viimeisinLupa },
@@ -58,25 +41,13 @@ const UusiAsiaDialogContainer = React.memo(
 
     return (
       <UusiAsiaDialog
-        history={history}
-        kielet={kielet}
         kohteet={kohteet}
-        koulutukset={koulutukset}
-        koulutusalat={koulutusalat}
-        koulutustyypit={koulutustyypit}
-        kunnat={kunnat}
         lisatiedot={lisatiedot}
         lupa={viimeisinLupa}
-        lupaKohteet={lupaKohteet}
-        maakunnat={maakunnat}
-        maakuntakunnat={maakuntakunnat}
+        lupakohteet={lupakohteet}
         maaraystyypit={maaraystyypit}
-        muut={muut}
         onNewDocSave={onNewDocSave}
-        opetuskielet={opetuskielet}
-        opetustehtavakoodisto={opetustehtavakoodisto}
         organisation={organisaatio}
-        tutkinnot={tutkinnot}
       />
     );
   }

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/Dialogit/Esittelijat/Lupanakyma/index.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/Dialogit/Esittelijat/Lupanakyma/index.js
@@ -49,40 +49,14 @@ const FormDialog = withStyles(() => ({
   return <Dialog {...props}>{props.children}</Dialog>;
 });
 
-const defaultProps = {
-  kielet: [],
-  kohteet: [],
-  koulutukset: {
-    muut: {},
-    poikkeukset: {}
-  },
-  koulutusalat: {},
-  koulutustyypit: {},
-  kunnat: [],
-  lisatiedot: [],
-  lupa: {},
-  lupaKohteet: {},
-  maakunnat: [],
-  maakuntakunnat: [],
-  maaraystyypit: [],
-  opetuskielet: [],
-  opetustehtavakoodisto: {},
-  organisation: {},
-  tutkinnot: []
-};
-
 const UusiAsiaDialog = ({
-  kohteet = defaultProps.kohteet,
-  kunnat = defaultProps.kunnat,
-  lisatiedot = defaultProps.lisatiedot,
-  lupa = defaultProps.lupa,
-  lupaKohteet = defaultProps.lupaKohteet,
-  maakunnat = defaultProps.maakunnat,
-  maakuntakunnat = defaultProps.maakuntakunnat,
-  maaraystyypit = defaultProps.maaraystyypit,
+  kohteet,
+  lisatiedot,
+  lupa,
+  lupakohteet,
+  maaraystyypit,
   onNewDocSave,
-  opetustehtavakoodisto = defaultProps.opetustehtavakoodisto,
-  organisation = defaultProps.organisation
+  organisation
 }) => {
   const [paatoksentiedotCo] = useChangeObjectsByAnchorWithoutUnderRemoval({
     anchor: "paatoksentiedot"
@@ -380,13 +354,8 @@ const UusiAsiaDialog = ({
                         style={{ height: isPreviewModeOn ? "86vh" : "auto" }}>
                         <LupanakymaA
                           isPreviewModeOn={false}
-                          kunnat={kunnat}
                           lisatiedot={lisatiedot}
-                          lupakohteet={lupaKohteet}
-                          maakunnat={maakunnat}
-                          maakuntakunnat={maakuntakunnat}
-                          opetustehtavakoodisto={opetustehtavakoodisto}
-                          uuid={uuid}
+                          lupakohteet={lupakohteet}
                           valtakunnallinenMaarays={valtakunnallinenMaarays}
                         />
                       </div>
@@ -413,12 +382,8 @@ const UusiAsiaDialog = ({
                           style={{ height: isPreviewModeOn ? "86vh" : "auto" }}>
                           <LupanakymaA
                             isPreviewModeOn={true}
-                            kunnat={kunnat}
                             lisatiedot={lisatiedot}
-                            lupakohteet={lupaKohteet}
-                            maakunnat={maakunnat}
-                            maakuntakunnat={maakuntakunnat}
-                            opetustehtavakoodisto={opetustehtavakoodisto}
+                            lupakohteet={lupakohteet}
                             valtakunnallinenMaarays={valtakunnallinenMaarays}
                           />
                         </div>
@@ -498,25 +463,13 @@ const UusiAsiaDialog = ({
 };
 
 UusiAsiaDialog.propTypes = {
-  history: PropTypes.object,
-  kielet: PropTypes.array,
-  koulutusalat: PropTypes.array,
   koulutustyypit: PropTypes.array,
-  kunnat: PropTypes.array,
   lisatiedot: PropTypes.array,
   lupa: PropTypes.object,
-  lupaKohteet: PropTypes.object,
-  maakunnat: PropTypes.array,
-  maakuntakunnat: PropTypes.array,
+  lupakohteet: PropTypes.object,
   maaraystyypit: PropTypes.array,
-  muut: PropTypes.array,
   onNewDocSave: PropTypes.func,
-  opetuskielet: PropTypes.array,
-  opetustehtavakoodisto: PropTypes.object,
-  organisation: PropTypes.object,
-  poErityisetKoulutustehtavat: PropTypes.array,
-  poMuutEhdot: PropTypes.array,
-  tutkinnot: PropTypes.array
+  organisation: PropTypes.object
 };
 
 export default UusiAsiaDialog;

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/1-Opetustehtavat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/1-Opetustehtavat.js
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import Lomake from "components/02-organisms/Lomake";
-import { toUpper } from "ramda";
+import { path, prop, toUpper } from "ramda";
+import { getOpetustehtavaKoodistoFromStorage } from "helpers/opetustehtavat";
 
 const constants = {
   mode: "modification",
@@ -13,13 +14,27 @@ const Opetustehtavat = ({
   code,
   isPreviewModeOn,
   mode = constants.mode,
-  opetustehtavakoodisto,
-  sectionId,
-  title
+  sectionId
 }) => {
   const intl = useIntl();
+  const [opetustehtavakoodisto, setOpetustehtavaKoodisto] = useState();
+  const title = prop(
+    "kuvaus",
+    path(["metadata", toUpper(intl.locale)], opetustehtavakoodisto)
+  );
 
-  return (
+  /** Fetch opetustehtavaKoodisto from storage */
+  useEffect(() => {
+    getOpetustehtavaKoodistoFromStorage()
+      .then(opetustehtavaKoodisto => {
+        setOpetustehtavaKoodisto(opetustehtavaKoodisto);
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  }, []);
+
+  return opetustehtavakoodisto ? (
     <Lomake
       anchor={sectionId}
       code={code}
@@ -30,16 +45,14 @@ const Opetustehtavat = ({
       path={constants.formLocation}
       rowTitle={opetustehtavakoodisto.metadata[toUpper(intl.locale)].nimi}
       showCategoryTitles={true}></Lomake>
-  );
+  ) : null;
 };
 
 Opetustehtavat.propTypes = {
   code: PropTypes.string,
   isPreviewModeOn: PropTypes.bool,
   mode: PropTypes.string,
-  opetustehtavakoodisto: PropTypes.object,
-  sectionId: PropTypes.string,
-  title: PropTypes.string
+  sectionId: PropTypes.string
 };
 
 export default Opetustehtavat;

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/10-rajoite.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/10-rajoite.js
@@ -18,18 +18,21 @@ import {
 
 const constants = {
   formLocation: ["esiJaPerusopetus", "rajoite"]
-}
+};
 
 const Rajoite = ({ onChangesUpdate, parentSectionId }) => {
-  const [changeObjectsByAnchor] = useChangeObjectsByMultipleAnchorsWithoutUnderRemoval({
+  const [
+    changeObjectsByAnchor
+  ] = useChangeObjectsByMultipleAnchorsWithoutUnderRemoval({
     anchors: [
-        "opetustehtavat",
-        "opetuskielet",
-        "toimintaalue",
-        "opetuksenJarjestamismuodot",
-        "erityisetKoulutustehtavat",
-        "opiskelijamaarat",
-        "muutEhdot"]
+      "opetustehtavat",
+      "opetuskielet",
+      "toimintaalue",
+      "opetuksenJarjestamismuodot",
+      "erityisetKoulutustehtavat",
+      "opiskelijamaarat",
+      "muutEhdot"
+    ]
   });
   const [state, actions] = useChangeObjects();
   const intl = useIntl();
@@ -67,10 +70,12 @@ const Rajoite = ({ onChangesUpdate, parentSectionId }) => {
           anchor={sectionId}
           data={{
             changeObjects: changeObjectsByAnchor,
-            onAddCriterion,
-            onRemoveCriterion,
             rajoiteId: restrictionId,
             sectionId
+          }}
+          functions={{
+            onAddCriterion,
+            onRemoveCriterion
           }}
           noPadding={true}
           onChangesUpdate={onChangesUpdate}

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/2-OpetustaAntavatKunnat copy.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/2-OpetustaAntavatKunnat copy.js
@@ -1,0 +1,385 @@
+import React, { useMemo, useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
+import common from "../../../../i18n/definitions/common";
+import wizard from "../../../../i18n/definitions/wizard";
+import Lomake from "../../../../components/02-organisms/Lomake";
+import { isAdded, isRemoved, isInLupa } from "../../../../css/label";
+import kuntaProvinceMapping from "../../../../utils/kuntaProvinceMapping";
+import * as R from "ramda";
+import { useChangeObjectsByAnchorWithoutUnderRemoval } from "stores/muutokset";
+
+const labelStyles = {
+  addition: isAdded,
+  removal: isRemoved
+};
+
+const constants = {
+  formLocation: ["esiJaPerusopetus", "opetustaAntavatKunnat"],
+  mode: "modification"
+};
+
+const mapping = {
+  "01": "FI-18",
+  "02": "FI-19",
+  "04": "FI-17",
+  "05": "FI-06",
+  "06": "FI-11",
+  "07": "FI-16",
+  "08": "FI-09",
+  "09": "FI-02",
+  "10": "FI-04",
+  "11": "FI-15",
+  "12": "FI-13",
+  "14": "FI-03",
+  "16": "FI-07",
+  "13": "FI-08",
+  "15": "FI-12",
+  "17": "FI-14",
+  "18": "FI-05",
+  "19": "FI-10",
+  "21": "FI-01"
+};
+
+const OpetustaAntavatKunnat = React.memo(
+  ({
+    code,
+    isPreviewModeOn,
+    mode = constants.mode,
+    kunnat,
+    kuntamaaraykset,
+    lisatiedot,
+    lupakohde,
+    maakunnat,
+    maakuntakunnat,
+    sectionId,
+    title,
+    valtakunnallinenMaarays
+  }) => {
+    const intl = useIntl();
+    const [
+      changeObjects,
+      { setChanges }
+    ] = useChangeObjectsByAnchorWithoutUnderRemoval({
+      anchor: sectionId
+    });
+
+    const [isEditViewActive, toggleEditView] = useState(false);
+
+    const ulkomaa = R.find(R.propEq("koodiarvo", "200"), kunnat);
+
+    const kunnatInLupa = useMemo(() => {
+      return R.sortBy(
+        R.path(["metadata", "arvo"]),
+        R.map(kunta => {
+          const maarays = R.find(
+            R.propEq("koodiarvo", kunta.koodiarvo),
+            kuntamaaraykset
+          );
+          return {
+            maaraysUuid: maarays ? maarays.uuid : null,
+            title: kunta.arvo,
+            metadata: kunta
+          };
+        }, lupakohde.kunnat || [])
+      );
+    }, [kuntamaaraykset, lupakohde.kunnat]);
+
+    const maakunnatInLupa = useMemo(() => {
+      return R.sortBy(
+        R.path(["metadata", "arvo"]),
+        R.map(maakunta => {
+          return {
+            title: maakunta.arvo,
+            metadata: maakunta
+          };
+        }, lupakohde.maakunnat || [])
+      );
+    }, [lupakohde.maakunnat]);
+
+    const fiCode = R.view(R.lensPath(["valtakunnallinen", "arvo"]), lupakohde);
+
+    const whenChanges = useCallback(
+      changes => {
+        console.info(changes);
+        const withoutCategoryFilterChangeObj = R.filter(
+          R.compose(R.not, R.propEq("anchor", `${sectionId}.categoryFilter`)),
+          changeObjects
+        );
+
+        const amountOfChanges = R.flatten(R.values(changes.changesByProvince))
+          .length;
+        const amountOfQuickFilterChanges = R.flatten(
+          R.values(changes.quickFilterChanges)
+        ).length;
+
+        const changesToSet = R.concat(
+          withoutCategoryFilterChangeObj,
+          amountOfChanges || amountOfQuickFilterChanges
+            ? [
+                {
+                  anchor: `${sectionId}.categoryFilter`,
+                  properties: {
+                    changesByProvince: changes.changesByProvince,
+                    quickFilterChanges: changes.quickFilterChanges
+                  }
+                }
+              ]
+            : []
+        );
+
+        return setChanges(changesToSet, sectionId);
+      },
+      [changeObjects, sectionId, setChanges]
+    );
+
+    /**
+     * Form structure will be created here.
+     */
+    const options = useMemo(() => {
+      const localeUpper = intl.locale.toUpperCase();
+      const maaraysUuid = valtakunnallinenMaarays.uuid;
+      return R.map(maakunta => {
+        // 21 = Ahvenanmaa, 99 = Ei tiedossa
+        if (maakunta.koodiarvo === "21" || maakunta.koodiarvo === "99") {
+          return null;
+        }
+
+        const isMaakuntaInLupa = !!R.find(province => {
+          return province.metadata.koodiarvo === maakunta.koodiarvo;
+        }, maakunnatInLupa);
+
+        let someMunicipalitiesInLupa = false;
+        let someMunicipalitiesNotInLupa = false;
+
+        const today = new Date();
+        const presentKunnat = R.filter(
+          ({ voimassaLoppuPvm }) =>
+            !voimassaLoppuPvm || new Date(voimassaLoppuPvm) >= today,
+          maakunta.kunnat
+        );
+
+        const municipalitiesOfProvince = R.map(kunta => {
+          const kunnanNimi = kunta.metadata[localeUpper].nimi;
+
+          const isKuntaInLupa = !!R.find(
+            R.pathEq(["metadata", "koodiarvo"], kunta.koodiarvo),
+            kunnatInLupa
+          );
+
+          if (isKuntaInLupa) {
+            someMunicipalitiesInLupa = true;
+          } else {
+            someMunicipalitiesNotInLupa = true;
+          }
+
+          return {
+            anchor: kunta.koodiarvo,
+            name: "CheckboxWithLabel",
+            styleClasses: ["w-1/2"],
+            properties: {
+              code: kunta.koodiarvo,
+              forChangeObject: {
+                koodiarvo: kunta.koodiarvo,
+                title: kunnanNimi,
+                maakuntaKey: mapping[maakunta.koodiarvo],
+                maaraysUuid
+              },
+              isChecked: isKuntaInLupa || isMaakuntaInLupa || fiCode === "FI1",
+              labelStyles: Object.assign({}, labelStyles, {
+                custom: isInLupa
+              }),
+              name: kunta.koodiarvo,
+              title: kunnanNimi
+            }
+          };
+        }, presentKunnat);
+
+        const isKuntaOfMaakuntaInLupa = !!R.find(kunta => {
+          let maakuntaCode;
+          const result = R.find(
+            k =>
+              R.propEq("kuntaKoodiarvo", kunta.metadata.koodiarvo, k) &&
+              R.includes(
+                k.kuntaKoodiarvo,
+                R.map(R.prop("koodiarvo"), presentKunnat)
+              ),
+            kuntaProvinceMapping
+          );
+
+          if (result) {
+            R.mapObjIndexed((value, key) => {
+              if (value === result.maakuntaKey) {
+                maakuntaCode = key;
+              }
+            }, mapping);
+          }
+          return maakuntaCode === maakunta.koodiarvo;
+        }, kunnatInLupa);
+
+        return {
+          anchor: mapping[maakunta.koodiarvo],
+          formId: mapping[maakunta.koodiarvo],
+          components: [
+            {
+              anchor: "A",
+              name: "CheckboxWithLabel",
+              properties: {
+                code: maakunta.koodiarvo,
+                forChangeObject: {
+                  koodiarvo: maakunta.koodiarvo,
+                  maakuntaKey: mapping[maakunta.koodiarvo],
+                  title: maakunta.label,
+                  maaraysUuid
+                },
+                isChecked:
+                  fiCode === "FI1" ||
+                  isMaakuntaInLupa ||
+                  isKuntaOfMaakuntaInLupa,
+                isIndeterminate:
+                  !isMaakuntaInLupa &&
+                  someMunicipalitiesInLupa &&
+                  someMunicipalitiesNotInLupa,
+                labelStyles: Object.assign({}, labelStyles, {
+                  custom: isInLupa
+                }),
+                name: maakunta.koodiarvo,
+                title: maakunta.metadata[localeUpper].nimi
+              }
+            }
+          ],
+          categories: [
+            {
+              anchor: "kunnat",
+              formId: mapping[maakunta.koodiarvo],
+              components: municipalitiesOfProvince
+            }
+          ]
+        };
+      }, maakuntakunnat).filter(Boolean);
+    }, [
+      intl.locale,
+      fiCode,
+      kunnatInLupa,
+      maakunnatInLupa,
+      maakuntakunnat,
+      valtakunnallinenMaarays
+    ]);
+
+    const kunnatWithoutAhvenanmaan = useMemo(() => {
+      return R.filter(kunta => {
+        const result = R.find(
+          R.propEq("kuntaKoodiarvo", kunta.koodiarvo),
+          kuntaProvinceMapping
+        );
+        return (
+          result && result.maakuntaKey !== "FI-01" && kunta.koodiarvo !== "200" // 200 Ulkomaa
+        );
+      }, kunnat);
+    }, [kunnat]);
+
+    const provincesWithoutAhvenanmaa = useMemo(() => {
+      return R.filter(maakunta => {
+        // 21 = Ahvenanmaa
+        return maakunta.koodiarvo !== "21";
+      }, maakunnat);
+    }, [maakunnat]);
+
+    const provinceChanges = useMemo(() => {
+      const changeObj = R.find(
+        R.propEq("anchor", `${sectionId}.categoryFilter`),
+        changeObjects
+      );
+      return changeObj ? changeObj.properties.changesByProvince : {};
+    }, [changeObjects, sectionId]);
+
+    const quickFilterChanges = useMemo(() => {
+      const changeObj = R.find(
+        R.propEq("anchor", `${sectionId}.categoryFilter`),
+        changeObjects
+      );
+      return changeObj ? changeObj.properties.quickFilterChanges : {};
+    }, [changeObjects, sectionId]);
+
+    const noSelectionsInLupa =
+      R.isEmpty(maakunnatInLupa) && R.isEmpty(kunnatInLupa) && fiCode !== "FI1";
+
+    return (
+      <Lomake
+        anchor={sectionId}
+        code={code}
+        formTitle={title}
+        mode={mode}
+        isInExpandableRow={true}
+        isPreviewModeOn={isPreviewModeOn}
+        isRowExpanded={true}
+        data={{
+          fiCode,
+          isEditViewActive,
+          isEiMaariteltyaToimintaaluettaChecked: fiCode === "FI2",
+          isValtakunnallinenChecked: fiCode === "FI1",
+          kunnat: kunnatWithoutAhvenanmaan,
+          lisatiedot: lisatiedot,
+          localizations: {
+            accept: intl.formatMessage(common.accept),
+            areaOfActionIsUndefined: intl.formatMessage(
+              wizard.noMunicipalitiesSelected
+            ),
+            cancel: intl.formatMessage(common.cancel),
+            currentAreaOfAction: intl.formatMessage(
+              wizard.municipalitiesInPresentLupa
+            ),
+            newAreaOfAction: noSelectionsInLupa
+              ? intl.formatMessage(wizard.municipalities)
+              : intl.formatMessage(wizard.municipalitiesInNewLupa),
+            ofMunicipalities: intl.formatMessage(wizard.ofMunicipalities),
+            quickFilter: intl.formatMessage(wizard.quickFilter),
+            editButtonText: intl.formatMessage(wizard.selectMunicipalities),
+            sameAsTheCurrentAreaOfAction: intl.formatMessage(
+              wizard.sameAsTheCurrentAreaOfAction
+            ),
+            wholeCountryWithoutAhvenanmaa: intl.formatMessage(
+              wizard.wholeCountryWithoutAhvenanmaa
+            )
+          },
+          ulkomaa,
+          maakunnat: provincesWithoutAhvenanmaa,
+          options,
+          changeObjectsByProvince: Object.assign({}, provinceChanges),
+          quickFilterChanges,
+          noSelectionsInLupa
+        }}
+        functions={{
+          onChanges: whenChanges,
+          toggleEditView
+        }}
+        path={constants.formLocation}
+        showCategoryTitles={true}
+        rowTitle={intl.formatMessage(wizard.municipalitiesAndAreas)}
+      />
+    );
+  }
+);
+
+OpetustaAntavatKunnat.defaultProps = {
+  kunnat: [],
+  kuntamaaraykset: [],
+  lisatiedot: [],
+  lupakohde: {},
+  maakunnat: [],
+  maakuntakunnat: [],
+  valtakunnallinenMaarays: {}
+};
+
+OpetustaAntavatKunnat.propTypes = {
+  kunnat: PropTypes.array,
+  lupakohde: PropTypes.object,
+  maakunnat: PropTypes.array,
+  maakuntakunnat: PropTypes.array,
+  kuntamaaraykset: PropTypes.array,
+  lisatiedot: PropTypes.array,
+  valtakunnallinenMaarays: PropTypes.object,
+  sectionId: PropTypes.string
+};
+
+export default OpetustaAntavatKunnat;

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/2-OpetustaAntavatKunnat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/2-OpetustaAntavatKunnat.js
@@ -1,381 +1,180 @@
 import React, { useMemo, useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
-import common from "../../../../i18n/definitions/common";
-import wizard from "../../../../i18n/definitions/wizard";
-import Lomake from "../../../../components/02-organisms/Lomake";
-import { isAdded, isRemoved, isInLupa } from "../../../../css/label";
-import kuntaProvinceMapping from "../../../../utils/kuntaProvinceMapping";
-import * as R from "ramda";
+import common from "i18n/definitions/common";
+import wizard from "i18n/definitions/wizard";
+import Lomake from "components/02-organisms/Lomake";
 import { useChangeObjectsByAnchorWithoutUnderRemoval } from "stores/muutokset";
-
-const labelStyles = {
-  addition: isAdded,
-  removal: isRemoved
-};
+import * as R from "ramda";
 
 const constants = {
   formLocation: ["esiJaPerusopetus", "opetustaAntavatKunnat"],
   mode: "modification"
 };
 
-const mapping = {
-  "01": "FI-18",
-  "02": "FI-19",
-  "04": "FI-17",
-  "05": "FI-06",
-  "06": "FI-11",
-  "07": "FI-16",
-  "08": "FI-09",
-  "09": "FI-02",
-  "10": "FI-04",
-  "11": "FI-15",
-  "12": "FI-13",
-  "14": "FI-03",
-  "16": "FI-07",
-  "13": "FI-08",
-  "15": "FI-12",
-  "17": "FI-14",
-  "18": "FI-05",
-  "19": "FI-10",
-  "21": "FI-01"
-};
+const OpetustaAntavatKunnat = React.memo(props => {
+  const intl = useIntl();
+  const [
+    changeObjects,
+    { setChanges }
+  ] = useChangeObjectsByAnchorWithoutUnderRemoval({
+    anchor: "toimintaalue"
+  });
 
-const OpetustaAntavatKunnat = React.memo(
-  ({
-    code,
-    isPreviewModeOn,
-    mode = constants.mode,
-    kunnat,
-    kuntamaaraykset,
-    lisatiedot,
-    lupakohde,
-    maakunnat,
-    maakuntakunnat,
-    sectionId,
-    title,
-    valtakunnallinenMaarays
-  }) => {
-    const intl = useIntl();
-    const [
-      changeObjects,
-      { setChanges }
-    ] = useChangeObjectsByAnchorWithoutUnderRemoval({
-      anchor: sectionId
-    });
+  const [isEditViewActive, toggleEditView] = useState(false);
 
-    const [isEditViewActive, toggleEditView] = useState(false);
-
-    const ulkomaa = R.find(R.propEq("koodiarvo", "200"), kunnat);
-
-    const kunnatInLupa = useMemo(() => {
-      return R.sortBy(
-        R.path(["metadata", "arvo"]),
-        R.map(kunta => {
-          const maarays = R.find(
-            R.propEq("koodiarvo", kunta.koodiarvo),
-            kuntamaaraykset
-          );
-          return {
-            maaraysUuid: maarays ? maarays.uuid : null,
-            title: kunta.arvo,
-            metadata: kunta
-          };
-        }, lupakohde.kunnat || [])
-      );
-    }, [kuntamaaraykset, lupakohde.kunnat]);
-
-    const maakunnatInLupa = useMemo(() => {
-      return R.sortBy(
-        R.path(["metadata", "arvo"]),
-        R.map(maakunta => {
-          return {
-            title: maakunta.arvo,
-            metadata: maakunta
-          };
-        }, lupakohde.maakunnat || [])
-      );
-    }, [lupakohde.maakunnat]);
-
-    const fiCode = R.view(R.lensPath(["valtakunnallinen", "arvo"]), lupakohde);
-
-    const whenChanges = useCallback(
-      changes => {
-        console.info(changes);
-        const withoutCategoryFilterChangeObj = R.filter(
-          R.compose(R.not, R.propEq("anchor", `${sectionId}.categoryFilter`)),
-          changeObjects
+  const kunnatInLupa = useMemo(() => {
+    return R.sortBy(
+      R.path(["metadata", "arvo"]),
+      R.map(kunta => {
+        const maarays = R.find(
+          R.propEq("koodiarvo", kunta.koodiarvo),
+          props.kuntamaaraykset
         );
-
-        const amountOfChanges = R.flatten(R.values(changes.changesByProvince))
-          .length;
-        const amountOfQuickFilterChanges = R.flatten(
-          R.values(changes.quickFilterChanges)
-        ).length;
-
-        const changesToSet = R.concat(
-          withoutCategoryFilterChangeObj,
-          amountOfChanges || amountOfQuickFilterChanges
-            ? [
-                {
-                  anchor: `${sectionId}.categoryFilter`,
-                  properties: {
-                    changesByProvince: changes.changesByProvince,
-                    quickFilterChanges: changes.quickFilterChanges
-                  }
-                }
-              ]
-            : []
-        );
-
-        return setChanges(changesToSet, sectionId);
-      },
-      [changeObjects, sectionId, setChanges]
-    );
-
-    /**
-     * Form structure will be created here.
-     */
-    const options = useMemo(() => {
-      const localeUpper = intl.locale.toUpperCase();
-      const maaraysUuid = valtakunnallinenMaarays.uuid;
-      return R.map(maakunta => {
-        // 21 = Ahvenanmaa, 99 = Ei tiedossa
-        if (maakunta.koodiarvo === "21" || maakunta.koodiarvo === "99") {
-          return null;
-        }
-
-        const isMaakuntaInLupa = !!R.find(province => {
-          return province.metadata.koodiarvo === maakunta.koodiarvo;
-        }, maakunnatInLupa);
-
-        let someMunicipalitiesInLupa = false;
-        let someMunicipalitiesNotInLupa = false;
-
-        const today = new Date();
-        const presentKunnat = R.filter(
-          ({ voimassaLoppuPvm }) =>
-            !voimassaLoppuPvm || new Date(voimassaLoppuPvm) >= today,
-          maakunta.kunnat
-        );
-
-        const municipalitiesOfProvince = R.map(kunta => {
-          const kunnanNimi = kunta.metadata[localeUpper].nimi;
-
-          const isKuntaInLupa = !!R.find(
-            R.pathEq(["metadata", "koodiarvo"], kunta.koodiarvo),
-            kunnatInLupa
-          );
-
-          if (isKuntaInLupa) {
-            someMunicipalitiesInLupa = true;
-          } else {
-            someMunicipalitiesNotInLupa = true;
-          }
-
-          return {
-            anchor: kunta.koodiarvo,
-            name: "CheckboxWithLabel",
-            styleClasses: ["w-1/2"],
-            properties: {
-              code: kunta.koodiarvo,
-              forChangeObject: {
-                koodiarvo: kunta.koodiarvo,
-                title: kunnanNimi,
-                maakuntaKey: mapping[maakunta.koodiarvo],
-                maaraysUuid
-              },
-              isChecked: isKuntaInLupa || isMaakuntaInLupa || fiCode === "FI1",
-              labelStyles: Object.assign({}, labelStyles, {
-                custom: isInLupa
-              }),
-              name: kunta.koodiarvo,
-              title: kunnanNimi
-            }
-          };
-        }, presentKunnat);
-
-        const isKuntaOfMaakuntaInLupa = !!R.find(kunta => {
-          let maakuntaCode;
-          const result = R.find(
-            k =>
-              R.propEq("kuntaKoodiarvo", kunta.metadata.koodiarvo, k) &&
-              R.includes(
-                k.kuntaKoodiarvo,
-                R.map(R.prop("koodiarvo"), presentKunnat)
-              ),
-            kuntaProvinceMapping
-          );
-
-          if (result) {
-            R.mapObjIndexed((value, key) => {
-              if (value === result.maakuntaKey) {
-                maakuntaCode = key;
-              }
-            }, mapping);
-          }
-          return maakuntaCode === maakunta.koodiarvo;
-        }, kunnatInLupa);
-
         return {
-          anchor: mapping[maakunta.koodiarvo],
-          formId: mapping[maakunta.koodiarvo],
-          components: [
-            {
-              anchor: "A",
-              name: "CheckboxWithLabel",
-              properties: {
-                code: maakunta.koodiarvo,
-                forChangeObject: {
-                  koodiarvo: maakunta.koodiarvo,
-                  maakuntaKey: mapping[maakunta.koodiarvo],
-                  title: maakunta.label,
-                  maaraysUuid
-                },
-                isChecked:
-                  fiCode === "FI1" ||
-                  isMaakuntaInLupa ||
-                  isKuntaOfMaakuntaInLupa,
-                isIndeterminate:
-                  !isMaakuntaInLupa &&
-                  someMunicipalitiesInLupa &&
-                  someMunicipalitiesNotInLupa,
-                labelStyles: Object.assign({}, labelStyles, {
-                  custom: isInLupa
-                }),
-                name: maakunta.koodiarvo,
-                title: maakunta.metadata[localeUpper].nimi
-              }
-            }
-          ],
-          categories: [
-            {
-              anchor: "kunnat",
-              formId: mapping[maakunta.koodiarvo],
-              components: municipalitiesOfProvince
-            }
-          ]
+          maaraysUuid: maarays ? maarays.uuid : null,
+          title: kunta.arvo,
+          metadata: kunta
         };
-      }, maakuntakunnat).filter(Boolean);
-    }, [
-      intl.locale,
-      fiCode,
-      kunnatInLupa,
-      maakunnatInLupa,
-      maakuntakunnat,
-      valtakunnallinenMaarays
-    ]);
-
-    const kunnatWithoutAhvenanmaan = useMemo(() => {
-      return R.filter(kunta => {
-        const result = R.find(
-          R.propEq("kuntaKoodiarvo", kunta.koodiarvo),
-          kuntaProvinceMapping
-        );
-        return (
-          result && result.maakuntaKey !== "FI-01" && kunta.koodiarvo !== "200" // 200 Ulkomaa
-        );
-      }, kunnat);
-    }, [kunnat]);
-
-    const provincesWithoutAhvenanmaa = useMemo(() => {
-      return R.filter(maakunta => {
-        // 21 = Ahvenanmaa
-        return maakunta.koodiarvo !== "21";
-      }, maakunnat);
-    }, [maakunnat]);
-
-    const provinceChanges = useMemo(() => {
-      const changeObj = R.find(
-        R.propEq("anchor", `${sectionId}.categoryFilter`),
-        changeObjects
-      );
-      return changeObj ? changeObj.properties.changesByProvince : {};
-    }, [changeObjects, sectionId]);
-
-    const quickFilterChanges = useMemo(() => {
-      const changeObj = R.find(
-        R.propEq("anchor", `${sectionId}.categoryFilter`),
-        changeObjects
-      );
-      return changeObj ? changeObj.properties.quickFilterChanges : {};
-    }, [changeObjects, sectionId]);
-
-    const noSelectionsInLupa =
-      R.isEmpty(maakunnatInLupa) && R.isEmpty(kunnatInLupa) && fiCode !== "FI1";
-
-    return (
-      <Lomake
-        anchor={sectionId}
-        code={code}
-        formTitle={title}
-        mode={mode}
-        isInExpandableRow={true}
-        isPreviewModeOn={isPreviewModeOn}
-        isRowExpanded={true}
-        data={{
-          fiCode,
-          isEditViewActive,
-          isEiMaariteltyaToimintaaluettaChecked: fiCode === "FI2",
-          isValtakunnallinenChecked: fiCode === "FI1",
-          kunnat: kunnatWithoutAhvenanmaan,
-          lisatiedot: lisatiedot,
-          localizations: {
-            accept: intl.formatMessage(common.accept),
-            areaOfActionIsUndefined: intl.formatMessage(
-              wizard.noMunicipalitiesSelected
-            ),
-            cancel: intl.formatMessage(common.cancel),
-            currentAreaOfAction: intl.formatMessage(
-              wizard.municipalitiesInPresentLupa
-            ),
-            newAreaOfAction: noSelectionsInLupa
-              ? intl.formatMessage(wizard.municipalities)
-              : intl.formatMessage(wizard.municipalitiesInNewLupa),
-            ofMunicipalities: intl.formatMessage(wizard.ofMunicipalities),
-            quickFilter: intl.formatMessage(wizard.quickFilter),
-            editButtonText: intl.formatMessage(wizard.selectMunicipalities),
-            sameAsTheCurrentAreaOfAction: intl.formatMessage(
-              wizard.sameAsTheCurrentAreaOfAction
-            ),
-            wholeCountryWithoutAhvenanmaa: intl.formatMessage(
-              wizard.wholeCountryWithoutAhvenanmaa
-            )
-          },
-          ulkomaa,
-          maakunnat: provincesWithoutAhvenanmaa,
-          onChanges: whenChanges,
-          toggleEditView,
-          options,
-          changeObjectsByProvince: Object.assign({}, provinceChanges),
-          quickFilterChanges,
-          noSelectionsInLupa
-        }}
-        path={constants.formLocation}
-        showCategoryTitles={true}
-        rowTitle={intl.formatMessage(wizard.municipalitiesAndAreas)}
-      />
+      }, props.lupakohde.kunnat || [])
     );
-  }
-);
+  }, [props.kuntamaaraykset, props.lupakohde.kunnat]);
+
+  const maakunnatInLupa = useMemo(() => {
+    return R.sortBy(
+      R.path(["metadata", "arvo"]),
+      R.map(maakunta => {
+        return {
+          title: maakunta.arvo,
+          metadata: maakunta
+        };
+      }, props.lupakohde.maakunnat || [])
+    );
+  }, [props.lupakohde.maakunnat]);
+
+  const fiCode = R.view(
+    R.lensPath(["valtakunnallinen", "arvo"]),
+    props.lupakohde
+  );
+
+  const whenChanges = useCallback(
+    changes => {
+      const withoutCategoryFilterChangeObj = R.filter(
+        R.compose(
+          R.not,
+          R.propEq("anchor", `${props.sectionId}.categoryFilter`)
+        ),
+        changeObjects
+      );
+
+      const amountOfChanges = R.flatten(R.values(changes.changesByProvince))
+        .length;
+      const amountOfQuickFilterChanges = R.flatten(
+        R.values(changes.quickFilterChanges)
+      ).length;
+
+      const changesToSet = R.concat(
+        withoutCategoryFilterChangeObj,
+        amountOfChanges || amountOfQuickFilterChanges
+          ? [
+              {
+                anchor: `${props.sectionId}.categoryFilter`,
+                properties: {
+                  changesByProvince: changes.changesByProvince,
+                  quickFilterChanges: changes.quickFilterChanges
+                }
+              }
+            ]
+          : []
+      );
+
+      return setChanges(changesToSet, props.sectionId);
+    },
+    [changeObjects, props.sectionId, setChanges]
+  );
+
+  const provinceChanges = useMemo(() => {
+    const changeObj = R.find(
+      R.propEq("anchor", `${props.sectionId}.categoryFilter`),
+      changeObjects
+    );
+    return changeObj ? changeObj.properties.changesByProvince : {};
+  }, [changeObjects, props.sectionId]);
+
+  const quickFilterChanges = useMemo(() => {
+    const changeObj = R.find(
+      R.propEq("anchor", `${props.sectionId}.categoryFilter`),
+      changeObjects
+    );
+    return changeObj ? changeObj.properties.quickFilterChanges : {};
+  }, [changeObjects, props.sectionId]);
+
+  const noSelectionsInLupa =
+    R.isEmpty(maakunnatInLupa) && R.isEmpty(kunnatInLupa) && fiCode !== "FI1";
+
+  return (
+    <Lomake
+      mode={constants.mode}
+      anchor={props.sectionId}
+      code={props.code}
+      data={{
+        fiCode,
+        isEditViewActive,
+        isEiMaariteltyaToimintaaluettaChecked: fiCode === "FI2",
+        isValtakunnallinenChecked: fiCode === "FI1",
+        lisatiedot: props.lisatiedot,
+        localizations: {
+          accept: intl.formatMessage(common.accept),
+          areaOfActionIsUndefined: intl.formatMessage(
+            wizard.noMunicipalitiesSelected
+          ),
+          cancel: intl.formatMessage(common.cancel),
+          currentAreaOfAction: intl.formatMessage(
+            wizard.municipalitiesInPresentLupa
+          ),
+          newAreaOfAction: noSelectionsInLupa
+            ? intl.formatMessage(wizard.municipalities)
+            : intl.formatMessage(wizard.municipalitiesInNewLupa),
+          ofMunicipalities: intl.formatMessage(wizard.ofMunicipalities),
+          quickFilter: intl.formatMessage(wizard.quickFilter),
+          editButtonText: intl.formatMessage(wizard.selectMunicipalities),
+          sameAsTheCurrentAreaOfAction: intl.formatMessage(
+            wizard.sameAsTheCurrentAreaOfAction
+          ),
+          wholeCountryWithoutAhvenanmaa: intl.formatMessage(
+            wizard.wholeCountryWithoutAhvenanmaa
+          )
+        },
+        kunnatInLupa,
+        maakunnatInLupa,
+        changeObjectsByProvince: Object.assign({}, provinceChanges),
+        quickFilterChanges,
+        valtakunnallinenMaarays: props.valtakunnallinenMaarays
+      }}
+      functions={{
+        onChanges: whenChanges,
+        toggleEditView
+      }}
+      isRowExpanded={true}
+      path={constants.formLocation}
+      rowTitle={intl.formatMessage(
+        wizard.singularMunicipalitiesOrTheWholeCountry
+      )}
+      showCategoryTitles={true}
+      formTitle={props.title}
+    />
+  );
+});
 
 OpetustaAntavatKunnat.defaultProps = {
-  kunnat: [],
   kuntamaaraykset: [],
-  lisatiedot: [],
   lupakohde: {},
-  maakunnat: [],
-  maakuntakunnat: [],
   valtakunnallinenMaarays: {}
 };
 
 OpetustaAntavatKunnat.propTypes = {
-  kunnat: PropTypes.array,
   lupakohde: PropTypes.object,
-  maakunnat: PropTypes.array,
-  maakuntakunnat: PropTypes.array,
   kuntamaaraykset: PropTypes.array,
-  lisatiedot: PropTypes.array,
   valtakunnallinenMaarays: PropTypes.object,
   sectionId: PropTypes.string
 };

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/5-ErityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/5-ErityisetKoulutustehtavat.js
@@ -32,7 +32,10 @@ const ErityisetKoulutustehtavat = ({
     <Lomake
       anchor={sectionId}
       code={code}
-      data={{ onAddButtonClick, sectionId }}
+      data={{ sectionId }}
+      functions={{
+        onAddButtonClick
+      }}
       formTitle={title}
       mode={mode}
       isPreviewModeOn={isPreviewModeOn}

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/7-MuutEhdot.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/7-MuutEhdot.js
@@ -31,7 +31,7 @@ const MuutEhdot = ({
     <Lomake
       anchor={sectionId}
       code={code}
-      data={{ onAddButtonClick }}
+      functions={{ onAddButtonClick }}
       formTitle={title}
       mode={mode}
       isPreviewModeOn={isPreviewModeOn}

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/9-Rajoitteet.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lomakeosiot/9-Rajoitteet.js
@@ -5,7 +5,7 @@ import { useChangeObjects } from "../../../../stores/muutokset";
 
 const constants = {
   formLocations: ["esiJaPerusopetus", "rajoitteet"]
-}
+};
 
 const Rajoitteet = ({ onChangesUpdate, sectionId }) => {
   const [state, actions] = useChangeObjects();
@@ -29,9 +29,9 @@ const Rajoitteet = ({ onChangesUpdate, sectionId }) => {
         isInExpandableRow={false}
         anchor={sectionId}
         data={{
-          changeObjects: state.changeObjects,
-          onAddRestriction
+          changeObjects: state.changeObjects
         }}
+        functions={{ onAddRestriction }}
         noPadding={true}
         onChangesUpdate={onChangesUpdate}
         path={constants.formLocations}

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lupanakymat/LupanakymaA.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lupanakymat/LupanakymaA.js
@@ -36,6 +36,7 @@ const LupanakymaA = ({
   valtakunnallinenMaarays
 }) => {
   const intl = useIntl();
+
   return (
     <div
       className={`p-6 bg-white ${

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lupanakymat/LupanakymaA.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/lupanakymat/LupanakymaA.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import PropTypes from "prop-types";
-import { toUpper } from "ramda";
 import common from "i18n/definitions/common";
 import education from "i18n/definitions/education";
 import Opetustehtavat from "../lomakeosiot/1-Opetustehtavat";
@@ -26,13 +25,8 @@ const constants = {
  */
 const LupanakymaA = ({
   isPreviewModeOn,
-  kunnat,
   lisatiedot,
   lupakohteet,
-  maakunnat,
-  maakuntakunnat,
-  opetustehtavakoodisto,
-  uuid,
   valtakunnallinenMaarays
 }) => {
   const intl = useIntl();
@@ -56,19 +50,14 @@ const LupanakymaA = ({
       <Opetustehtavat
         code="1"
         isPreviewModeOn={isPreviewModeOn}
-        opetustehtavakoodisto={opetustehtavakoodisto}
         sectionId="opetustehtavat"
-        title={opetustehtavakoodisto.metadata[toUpper(intl.locale)].kuvaus}
       />
 
       <OpetustaAntavatKunnat
         code="2"
         isPreviewModeOn={isPreviewModeOn}
-        kunnat={kunnat}
         lisatiedot={lisatiedot}
         lupakohde={lupakohteet[3]}
-        maakunnat={maakunnat}
-        maakuntakunnat={maakuntakunnat}
         sectionId="toimintaalue"
         title={intl.formatMessage(education.opetustaAntavatKunnat)}
         valtakunnallinenMaarays={valtakunnallinenMaarays}
@@ -125,7 +114,6 @@ LupanakymaA.propTypes = {
   code: PropTypes.string,
   isPreviewModeOn: PropTypes.bool,
   mode: PropTypes.string,
-  opetustehtavakoodisto: PropTypes.object,
   sectionId: PropTypes.string,
   title: PropTypes.string
 };

--- a/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat copy.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat copy.js
@@ -1,0 +1,142 @@
+import { isAdded, isInLupa, isRemoved } from "css/label";
+import { __ } from "i18n-for-browser";
+import { find, flatten, pathEq, toUpper } from "ramda";
+
+export const opetustaAntavatKunnat = (
+  data,
+  { isPreviewModeOn, isReadOnly },
+  locale,
+  changeObjects,
+  { onChanges, toggleEditView }
+) => {
+  const lisatiedotObj = find(
+    pathEq(["koodisto", "koodistoUri"], "lisatietoja"),
+    data.lisatiedot
+  );
+
+  const _isReadOnly = isPreviewModeOn || isReadOnly;
+
+  return flatten(
+    [
+      {
+        anchor: "valintakentta",
+        components: [
+          {
+            anchor: "maakunnatjakunnat",
+            name: "CategoryFilter",
+            styleClasses: ["mt-4"],
+            properties: {
+              anchor: "areaofaction",
+              changeObjectsByProvince: data.changeObjectsByProvince,
+              isPreviewModeOn,
+              isEditViewActive: data.isEditViewActive,
+              localizations: data.localizations,
+              municipalities: data.kunnat,
+              onChanges,
+              toggleEditView,
+              provinces: data.options,
+              provincesWithoutMunicipalities: data.maakunnat,
+              quickFilterChanges: data.quickFilterChanges,
+              showCategoryTitles: false,
+              nothingInLupa: data.noSelectionsInLupa,
+              koulutustyyppi: "esiJaPerusopetus"
+            }
+          }
+        ]
+      },
+      !!data.ulkomaa
+        ? {
+            anchor: "ulkomaa",
+            components: [
+              {
+                anchor: data.ulkomaa.koodiarvo,
+                name: "CheckboxWithLabel",
+                properties: {
+                  forChangeObject: {
+                    koodiarvo: data.ulkomaa.koodiarvo,
+                    koodisto: data.ulkomaa.koodisto,
+                    versio: data.ulkomaa.versio,
+                    voimassaAlkuPvm: data.ulkomaa.voimassaAlkuPvm
+                  },
+                  labelStyles: {
+                    addition: isAdded,
+                    removal: isRemoved,
+                    // TODO: määritä oikea ehto ja arvo
+                    custom: Object.assign({}, !!false ? isInLupa : {})
+                  },
+                  isChecked: false,
+                  isIndeterminate: false,
+                  isPreviewModeOn,
+                  isReadOnly: _isReadOnly,
+                  title: __("education.opetustaSuomenUlkopuolella")
+                },
+                styleClasses: ["mt-8"]
+              }
+            ],
+            categories: [
+              {
+                anchor: data.ulkomaa.koodiarvo,
+                components: [
+                  {
+                    anchor: "lisatiedot",
+                    name: "TextBox",
+                    properties: {
+                      forChangeObject: {
+                        koodiarvo: data.ulkomaa.koodiarvo,
+                        koodisto: data.ulkomaa.koodisto,
+                        versio: data.ulkomaa.versio,
+                        voimassaAlkuPvm: data.ulkomaa.voimassaAlkuPvm
+                      },
+                      isPreviewModeOn,
+                      isReadOnly: _isReadOnly,
+                      placeholder: __("common.maaJaPaikkakunta"),
+                      title: __("common.maaJaPaikkakunta")
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        : null,
+      lisatiedotObj
+        ? [
+            {
+              anchor: "lisatiedotTitle",
+              layout: { margins: { top: "large" } },
+              components: [
+                {
+                  anchor: lisatiedotObj.koodiarvo,
+                  name: "StatusTextRow",
+                  styleClasses: ["pt-8", "border-t"],
+                  properties: {
+                    title: __("common.lisatiedotInfo")
+                  }
+                }
+              ]
+            },
+            {
+              anchor: "lisatiedot",
+              components: [
+                {
+                  anchor: lisatiedotObj.koodiarvo,
+                  name: "TextBox",
+                  properties: {
+                    forChangeObject: {
+                      koodiarvo: lisatiedotObj.koodiarvo,
+                      koodisto: lisatiedotObj.koodisto,
+                      versio: lisatiedotObj.versio,
+                      voimassaAlkuPvm: lisatiedotObj.voimassaAlkuPvm
+                    },
+                    isPreviewModeOn,
+                    isReadOnly: _isReadOnly,
+                    placeholder: (lisatiedotObj.metadata[toUpper(locale)] || {})
+                      .nimi
+                  }
+                }
+              ]
+            }
+          ]
+        : null
+    ].filter(Boolean)
+  );
+};

--- a/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
@@ -14,8 +14,6 @@ export const opetustaAntavatKunnat = (
 
   const _isReadOnly = isPreviewModeOn || isReadOnly;
 
-  console.info(data);
-
   return flatten(
     [
       {

--- a/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
@@ -1,6 +1,7 @@
 import { getKunnatFromStorage } from "helpers/kunnat";
 import { getMaakunnat, getMaakuntakunnat } from "helpers/maakunnat";
 import {
+  compose,
   flatten,
   filter,
   find,
@@ -8,6 +9,7 @@ import {
   isEmpty,
   map,
   mapObjIndexed,
+  not,
   pathEq,
   prop,
   propEq,
@@ -65,6 +67,12 @@ export const opetustaAntavatKunnat = async (
   const maakunnat = await getMaakunnat();
   const maakuntakunnat = await getMaakuntakunnat();
   const ulkomaa = find(propEq("koodiarvo", "200"), kunnat);
+
+  const kunnatIlmanUlkomaata = filter(
+    // 200 = Ulkomaa
+    compose(not, propEq("koodiarvo", "200")),
+    kunnat
+  );
 
   const localeUpper = toUpper(locale);
   const maaraysUuid = valtakunnallinenMaarays.uuid;
@@ -199,7 +207,7 @@ export const opetustaAntavatKunnat = async (
               changeObjectsByProvince,
               isEditViewActive,
               localizations,
-              municipalities: kunnat,
+              municipalities: kunnatIlmanUlkomaata,
               onChanges,
               toggleEditView,
               provinces: options,

--- a/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/2-opetustaAntavatKunnat.js
@@ -1,18 +1,189 @@
-import { isAdded, isInLupa, isRemoved } from "css/label";
+import { getKunnatFromStorage } from "helpers/kunnat";
+import { getMaakunnat, getMaakuntakunnat } from "helpers/maakunnat";
+import {
+  flatten,
+  filter,
+  find,
+  includes,
+  isEmpty,
+  map,
+  mapObjIndexed,
+  pathEq,
+  prop,
+  propEq,
+  toUpper
+} from "ramda";
+import { isAdded, isRemoved, isInLupa } from "css/label";
+import kuntaProvinceMapping from "utils/kuntaProvinceMapping";
 import { __ } from "i18n-for-browser";
-import { find, flatten, pathEq, toUpper } from "ramda";
 
-export const opetustaAntavatKunnat = (
-  data,
-  { isPreviewModeOn, isReadOnly },
-  locale
+const labelStyles = {
+  addition: isAdded,
+  removal: isRemoved
+};
+
+const mapping = {
+  "01": "FI-18",
+  "02": "FI-19",
+  "04": "FI-17",
+  "05": "FI-06",
+  "06": "FI-11",
+  "07": "FI-16",
+  "08": "FI-09",
+  "09": "FI-02",
+  "10": "FI-04",
+  "11": "FI-15",
+  "12": "FI-13",
+  "14": "FI-03",
+  "16": "FI-07",
+  "13": "FI-08",
+  "15": "FI-12",
+  "17": "FI-14",
+  "18": "FI-05",
+  "19": "FI-10",
+  "21": "FI-01"
+};
+
+export const opetustaAntavatKunnat = async (
+  {
+    fiCode,
+    isEditViewActive,
+    changeObjectsByProvince = {},
+    lisatiedot,
+    localizations,
+    kunnatInLupa,
+    maakunnatInLupa,
+    quickFilterChanges = [],
+    valtakunnallinenMaarays
+  },
+  { isReadOnly },
+  locale,
+  changeObjects,
+  { onChanges, toggleEditView }
 ) => {
+  const kunnat = await getKunnatFromStorage();
+  const maakunnat = await getMaakunnat();
+  const maakuntakunnat = await getMaakuntakunnat();
+  const ulkomaa = find(propEq("koodiarvo", "200"), kunnat);
+
+  const localeUpper = toUpper(locale);
+  const maaraysUuid = valtakunnallinenMaarays.uuid;
+  const options = map(maakunta => {
+    const isMaakuntaInLupa = !!find(province => {
+      return province.metadata.koodiarvo === maakunta.koodiarvo;
+    }, maakunnatInLupa);
+
+    let someMunicipalitiesInLupa = false;
+
+    let someMunicipalitiesNotInLupa = false;
+
+    const today = new Date();
+
+    const presentKunnat = filter(
+      ({ voimassaLoppuPvm }) =>
+        !voimassaLoppuPvm || new Date(voimassaLoppuPvm) >= today,
+      maakunta.kunnat
+    );
+
+    const municipalitiesOfProvince = map(kunta => {
+      const kunnanNimi = kunta.metadata[localeUpper].nimi;
+
+      const isKuntaInLupa = !!find(
+        pathEq(["metadata", "koodiarvo"], kunta.koodiarvo),
+        kunnatInLupa
+      );
+
+      if (isKuntaInLupa) {
+        someMunicipalitiesInLupa = true;
+      } else {
+        someMunicipalitiesNotInLupa = true;
+      }
+
+      return {
+        anchor: kunta.koodiarvo,
+        name: "CheckboxWithLabel",
+        styleClasses: ["w-1/2"],
+        properties: {
+          code: kunta.koodiarvo,
+          forChangeObject: {
+            koodiarvo: kunta.koodiarvo,
+            title: kunnanNimi,
+            maakuntaKey: mapping[maakunta.koodiarvo],
+            maaraysUuid
+          },
+          isChecked: isKuntaInLupa || isMaakuntaInLupa || fiCode === "FI1",
+          labelStyles: Object.assign({}, labelStyles, {
+            custom: isInLupa
+          }),
+          name: kunta.koodiarvo,
+          title: kunnanNimi
+        }
+      };
+    }, presentKunnat);
+
+    const isKuntaOfMaakuntaInLupa = !!find(kunta => {
+      let maakuntaCode;
+      const result = find(
+        k =>
+          propEq("kuntaKoodiarvo", kunta.metadata.koodiarvo, k) &&
+          includes(k.kuntaKoodiarvo, map(prop("koodiarvo"), presentKunnat)),
+        kuntaProvinceMapping
+      );
+      if (result) {
+        mapObjIndexed((value, key) => {
+          if (value === result.maakuntaKey) {
+            maakuntaCode = key;
+          }
+        }, mapping);
+      }
+      return maakuntaCode === maakunta.koodiarvo;
+    }, kunnatInLupa);
+    return {
+      anchor: mapping[maakunta.koodiarvo],
+      formId: mapping[maakunta.koodiarvo],
+      components: [
+        {
+          anchor: "A",
+          name: "CheckboxWithLabel",
+          properties: {
+            code: maakunta.koodiarvo,
+            forChangeObject: {
+              koodiarvo: maakunta.koodiarvo,
+              maakuntaKey: mapping[maakunta.koodiarvo],
+              title: maakunta.label,
+              maaraysUuid
+            },
+            isChecked:
+              fiCode === "FI1" || isMaakuntaInLupa || isKuntaOfMaakuntaInLupa,
+            isIndeterminate:
+              !isMaakuntaInLupa &&
+              someMunicipalitiesInLupa &&
+              someMunicipalitiesNotInLupa,
+            labelStyles: Object.assign({}, labelStyles, {
+              custom: isInLupa
+            }),
+            name: maakunta.koodiarvo,
+            title: maakunta.metadata[localeUpper].nimi
+          }
+        }
+      ],
+      categories: [
+        {
+          anchor: "kunnat",
+          formId: mapping[maakunta.koodiarvo],
+          components: municipalitiesOfProvince
+        }
+      ]
+    };
+  }, maakuntakunnat).filter(Boolean);
+
   const lisatiedotObj = find(
     pathEq(["koodisto", "koodistoUri"], "lisatietoja"),
-    data.lisatiedot
+    lisatiedot
   );
 
-  const _isReadOnly = isPreviewModeOn || isReadOnly;
+  const noSelectionsInLupa =
+    isEmpty(maakunnatInLupa) && isEmpty(kunnatInLupa) && fiCode !== "FI1";
 
   return flatten(
     [
@@ -25,36 +196,35 @@ export const opetustaAntavatKunnat = (
             styleClasses: ["mt-4"],
             properties: {
               anchor: "areaofaction",
-              changeObjectsByProvince: data.changeObjectsByProvince,
-              isPreviewModeOn,
-              isEditViewActive: data.isEditViewActive,
-              localizations: data.localizations,
-              municipalities: data.kunnat,
-              onChanges: data.onChanges,
-              toggleEditView: data.toggleEditView,
-              provinces: data.options,
-              provincesWithoutMunicipalities: data.maakunnat,
-              quickFilterChanges: data.quickFilterChanges,
+              changeObjectsByProvince,
+              isEditViewActive,
+              localizations,
+              municipalities: kunnat,
+              onChanges,
+              toggleEditView,
+              provinces: options,
+              provincesWithoutMunicipalities: maakunnat,
               showCategoryTitles: false,
-              nothingInLupa: data.noSelectionsInLupa,
+              quickFilterChanges: quickFilterChanges,
+              nothingInLupa: noSelectionsInLupa,
               koulutustyyppi: "esiJaPerusopetus"
             }
           }
         ]
       },
-      !!data.ulkomaa
+      !!ulkomaa
         ? {
             anchor: "ulkomaa",
             components: [
               {
-                anchor: data.ulkomaa.koodiarvo,
+                anchor: ulkomaa.koodiarvo,
                 name: "CheckboxWithLabel",
                 properties: {
                   forChangeObject: {
-                    koodiarvo: data.ulkomaa.koodiarvo,
-                    koodisto: data.ulkomaa.koodisto,
-                    versio: data.ulkomaa.versio,
-                    voimassaAlkuPvm: data.ulkomaa.voimassaAlkuPvm
+                    koodiarvo: ulkomaa.koodiarvo,
+                    koodisto: ulkomaa.koodisto,
+                    versio: ulkomaa.versio,
+                    voimassaAlkuPvm: ulkomaa.voimassaAlkuPvm
                   },
                   labelStyles: {
                     addition: isAdded,
@@ -64,8 +234,7 @@ export const opetustaAntavatKunnat = (
                   },
                   isChecked: false,
                   isIndeterminate: false,
-                  isPreviewModeOn,
-                  isReadOnly: _isReadOnly,
+                  isReadOnly,
                   title: __("education.opetustaSuomenUlkopuolella")
                 },
                 styleClasses: ["mt-8"]
@@ -73,20 +242,19 @@ export const opetustaAntavatKunnat = (
             ],
             categories: [
               {
-                anchor: data.ulkomaa.koodiarvo,
+                anchor: ulkomaa.koodiarvo,
                 components: [
                   {
                     anchor: "lisatiedot",
                     name: "TextBox",
                     properties: {
                       forChangeObject: {
-                        koodiarvo: data.ulkomaa.koodiarvo,
-                        koodisto: data.ulkomaa.koodisto,
-                        versio: data.ulkomaa.versio,
-                        voimassaAlkuPvm: data.ulkomaa.voimassaAlkuPvm
+                        koodiarvo: ulkomaa.koodiarvo,
+                        koodisto: ulkomaa.koodisto,
+                        versio: ulkomaa.versio,
+                        voimassaAlkuPvm: ulkomaa.voimassaAlkuPvm
                       },
-                      isPreviewModeOn,
-                      isReadOnly: _isReadOnly,
+                      isReadOnly,
                       placeholder: __("common.maaJaPaikkakunta"),
                       title: __("common.maaJaPaikkakunta")
                     }
@@ -125,8 +293,7 @@ export const opetustaAntavatKunnat = (
                       versio: lisatiedotObj.versio,
                       voimassaAlkuPvm: lisatiedotObj.voimassaAlkuPvm
                     },
-                    isPreviewModeOn,
-                    isReadOnly: _isReadOnly,
+                    isReadOnly,
                     placeholder: (lisatiedotObj.metadata[toUpper(locale)] || {})
                       .nimi
                   }

--- a/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
@@ -24,7 +24,8 @@ export async function erityisetKoulutustehtavat(
   data,
   { isPreviewModeOn, isReadOnly },
   locale,
-  changeObjects
+  changeObjects,
+  { onAddButtonClick }
 ) {
   const _isReadOnly = isPreviewModeOn || isReadOnly;
   const poErityisetKoulutustehtavat = await getPOErityisetKoulutustehtavatFromStorage();
@@ -139,7 +140,7 @@ export async function erityisetKoulutustehtavat(
                   {
                     anchor: "A",
                     name: "SimpleButton",
-                    onClick: data.onAddButtonClick,
+                    onClick: onAddButtonClick,
                     properties: {
                       isPreviewModeOn,
                       isReadOnly: _isReadOnly,

--- a/src/services/lomakkeet/esi-ja-perusopetus/7-muutEhdot.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/7-muutEhdot.js
@@ -22,7 +22,8 @@ export async function muutEhdot(
   data,
   { isPreviewModeOn, isReadOnly },
   locale,
-  changeObjects
+  changeObjects,
+  { onAddButtonClick }
 ) {
   const _isReadOnly = isPreviewModeOn || isReadOnly;
   const poMuutEhdot = await getPOMuutEhdotFromStorage();
@@ -136,7 +137,7 @@ export async function muutEhdot(
                       {
                         anchor: "A",
                         name: "SimpleButton",
-                        onClick: () => data.onAddButtonClick(ehto.koodiarvo),
+                        onClick: () => onAddButtonClick(ehto.koodiarvo),
                         properties: {
                           isPreviewModeOn,
                           isReadOnly: _isReadOnly,

--- a/src/services/lomakkeet/esi-ja-perusopetus/esikatselu/3-opetuskielet.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/esikatselu/3-opetuskielet.js
@@ -24,8 +24,6 @@ export async function previewOfOpetuskielet({ lomakedata }) {
     lomakedata
   );
 
-  console.info(ensisijaiset, toissijaiset);
-
   const ensisijaisetListItems = !!ensisijaiset
     ? sortBy(
         prop("content"),

--- a/src/services/lomakkeet/esi-ja-perusopetus/esikatselu/4-opetuksenJarjestamismuoto.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/esikatselu/4-opetuksenJarjestamismuoto.js
@@ -45,8 +45,6 @@ export const previewOfOpetuksenJarjestamismuoto = ({ lomakedata }) => {
     lomakedata
   );
 
-  console.info(lisatiedotNode);
-
   if (lisatiedotNode && lisatiedotNode.properties.value) {
     structure = append(
       {

--- a/src/services/lomakkeet/esi-ja-perusopetus/rajoitteet/9-rajoitteet.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/rajoitteet/9-rajoitteet.js
@@ -19,7 +19,13 @@ const getKohteenTarkenninValue = changeObj => {
   }
 };
 
-export function rajoitteet(data, isReadOnly, locale, changeObjects) {
+export function rajoitteet(
+  data,
+  isReadOnly,
+  locale,
+  changeObjects,
+  { onAddRestriction }
+) {
   // data.restrictions = luvalta tulevat rajoitteet
   const changeObjectsByRajoiteId = groupBy(
     compose(nth(1), split("."), prop("anchor")),
@@ -135,7 +141,7 @@ export function rajoitteet(data, isReadOnly, locale, changeObjects) {
           {
             anchor: "painike",
             name: "SimpleButton",
-            onClick: data.onAddRestriction,
+            onClick: onAddRestriction,
             properties: {
               text: "Lisää rajoite"
             }

--- a/src/services/lomakkeet/esi-ja-perusopetus/rajoitteet/rajoitukset/1-opetustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/rajoitteet/rajoitukset/1-opetustehtavat.js
@@ -9,8 +9,6 @@ export default async function getOpetustehtavatLomake(
   const opetustehtavat = await getOpetustehtavatFromStorage();
   const localeUpper = toUpper(locale);
 
-  console.info(changeObjects, opetustehtavat, locale);
-
   if (opetustehtavat.length) {
     return {
       anchor: "rajoitus",
@@ -23,7 +21,6 @@ export default async function getOpetustehtavatLomake(
               const maarays = false; // TO DO: Etsi opetustehtävää koskeva määräys
               const anchor = `opetustehtavat.opetustehtava.${opetustehtava.koodiarvo}`;
               const changeObj = getChangeObjByAnchor(anchor, changeObjects);
-              console.info(changeObj);
               return (!!maarays &&
                 (!changeObj || changeObj.properties.isChecked)) ||
                 (changeObj && changeObj.properties.isChecked)

--- a/src/services/lomakkeet/index.js
+++ b/src/services/lomakkeet/index.js
@@ -18,7 +18,7 @@ import getTutkinnotPerustelulomake from "./perustelut/tutkinnot/";
 import getTutkinnotLomake from "./tutkinnot";
 import getOpetuskieletLomake from "./kielet/opetuskielet";
 import getTutkintokieletLomake from "./kielet/tutkintokielet";
-import getToimintaaluelomake from "./toimintaalue";
+import { getToimintaaluelomake } from "./toimintaalue";
 import getOpiskelijavuodetLomake from "./opiskelijavuodet";
 import getPerustelutLiitteetlomake from "./perustelut/liitteet";
 import getYhteenvetoLiitteetLomake from "./yhteenveto/liitteet";
@@ -142,12 +142,12 @@ const lomakkeet = {
     }
   },
   toimintaalue: {
-    modification: (data, booleans, locale) =>
-      getToimintaaluelomake("modification", data, booleans, locale)
+    modification: (data, booleans, locale, changeObjects, functions) =>
+      getToimintaaluelomake(data, booleans, locale, changeObjects, functions)
   },
   opiskelijavuodet: {
     modification: (data, booleans, locale) =>
-      getOpiskelijavuodetLomake("modification", data, booleans, locale)
+      getOpiskelijavuodetLomake(data, booleans, locale)
   },
 
   // Wizard page 2 forms
@@ -159,12 +159,7 @@ const lomakkeet = {
       },
       tutkintokielet: {
         reasoning: (data, booleans, locale) =>
-          getTutkintokieletPerustelulomake(
-            "reasoning",
-            data,
-            booleans,
-            locale
-          )
+          getTutkintokieletPerustelulomake("reasoning", data, booleans, locale)
       }
     },
     koulutukset: {
@@ -336,8 +331,14 @@ const lomakkeet = {
   // Esi- ja perusopetus
   esiJaPerusopetus: {
     erityisetKoulutustehtavat: {
-      modification: (data, booleans, locale, changeObjects) =>
-        erityisetKoulutustehtavat(data, booleans, locale, changeObjects),
+      modification: (data, booleans, locale, changeObjects, functions) =>
+        erityisetKoulutustehtavat(
+          data,
+          booleans,
+          locale,
+          changeObjects,
+          functions
+        ),
       preview: (data, booleans, locale, changeObjects) =>
         previewOfErityisetKoulutustehtavat(
           data,
@@ -347,8 +348,8 @@ const lomakkeet = {
         )
     },
     muutEhdot: {
-      modification: (data, booleans, locale, changeObjects) =>
-        muutEhdot(data, booleans, locale, changeObjects),
+      modification: (data, booleans, locale, changeObjects, functions) =>
+        muutEhdot(data, booleans, locale, changeObjects, functions),
       preview: (data, booleans, locale, changeObjects) =>
         previewOfMuutEhdot(data, booleans, locale, changeObjects)
     },
@@ -385,18 +386,24 @@ const lomakkeet = {
         getPaatoksenTiedot(data, booleans, locale, changeObjects)
     },
     opetustaAntavatKunnat: {
-      modification: (data, booleans, locale) =>
-        opetustaAntavatKunnat(data, booleans, locale),
-      preview: (data, booleans, locale) =>
-        previewOfOpetustaAntavaKunnat(data, booleans, locale)
+      modification: (data, booleans, locale, changeObjects, functions) =>
+        opetustaAntavatKunnat(data, booleans, locale, changeObjects, functions),
+      preview: (data, booleans, locale, changeObjects, functions) =>
+        previewOfOpetustaAntavaKunnat(
+          data,
+          booleans,
+          locale,
+          changeObjects,
+          functions
+        )
     },
     rajoite: {
-      addition: (data, booleans, locale, changeObjects) =>
-        rajoitelomake(data, booleans, locale, changeObjects)
+      addition: (data, booleans, locale, changeObjects, functions) =>
+        rajoitelomake(data, booleans, locale, changeObjects, functions)
     },
     rajoitteet: {
-      addition: (data, booleans, locale, changeObjects) =>
-        rajoitteet(data, booleans, locale, changeObjects)
+      addition: (data, booleans, locale, changeObjects, functions) =>
+        rajoitteet(data, booleans, locale, changeObjects, functions)
     }
   }
 };
@@ -405,6 +412,7 @@ export async function getLomake(
   mode = "addition",
   changeObjects = [],
   data = {},
+  functions = {},
   booleans,
   locale,
   _path = [],
@@ -414,7 +422,7 @@ export async function getLomake(
   setLocale(locale);
   const fn = path(append(mode, _path), lomakkeet);
   const lomake = fn
-    ? await fn(data, booleans, locale, changeObjects, prefix)
+    ? await fn(data, booleans, locale, changeObjects, functions, prefix)
     : [];
 
   return lomake;

--- a/src/services/lomakkeet/perustelut/muut.js
+++ b/src/services/lomakkeet/perustelut/muut.js
@@ -432,7 +432,6 @@ export const getOpiskelijavuodetVahimmaisopiskelijavuosimaaraPerustelulomake = (
     locale,
     isReadOnly
   );
-  console.info(checkboxes);
   return [
     {
       anchor: "vahimmaisopiskelijavuodet",

--- a/src/services/lomakkeet/perustelut/muutMuutokset/index.js
+++ b/src/services/lomakkeet/perustelut/muutMuutokset/index.js
@@ -153,7 +153,6 @@ function divideArticles(
 }
 
 function getCategoryData(dividedArticles, areaCode) {
-  console.info(areaCode, dividedArticles);
   switch (areaCode) {
     case "01":
       return {
@@ -330,7 +329,6 @@ export default function getMuutPerustelulomake(
   { isReadOnly },
   locale
 ) {
-  console.info(locale);
   switch (action) {
     case "reasoning":
       const defaultAdditionForm = getDefaultAdditionForm(isReadOnly);
@@ -341,7 +339,6 @@ export default function getMuutPerustelulomake(
         locale,
         defaultRemovalForm
       );
-      console.info(data);
       return getReasoningForm(
         data.areaCode,
         defaultAdditionForm,

--- a/src/services/lomakkeet/toimintaalue/index.js
+++ b/src/services/lomakkeet/toimintaalue/index.js
@@ -1,11 +1,13 @@
 import { getKunnatFromStorage } from "helpers/kunnat";
 import { getMaakunnat, getMaakuntakunnat } from "helpers/maakunnat";
 import {
+  compose,
   filter,
   find,
   includes,
   map,
   mapObjIndexed,
+  not,
   pathEq,
   prop,
   propEq,
@@ -57,7 +59,11 @@ export const getToimintaaluelomake = async (
   changeObjects,
   { onChanges, toggleEditView }
 ) => {
-  const kunnat = await getKunnatFromStorage();
+  const kunnat = filter(
+    // 200 = Ulkomaa
+    compose(not, propEq("koodiarvo", "200")),
+    await getKunnatFromStorage()
+  );
   const maakunnat = await getMaakunnat();
   const maakuntakunnat = await getMaakuntakunnat();
 

--- a/src/services/lomakkeet/toimintaalue/index.js
+++ b/src/services/lomakkeet/toimintaalue/index.js
@@ -1,14 +1,177 @@
-const getModificationForm = (
-  isEditViewActive,
-  changeObjectsByProvince = {},
-  quickFilterChanges = [],
-  options = [],
-  onChanges,
-  kunnat,
-  maakunnat,
-  localizations,
-  toggleEditView
+import { getKunnatFromStorage } from "helpers/kunnat";
+import { getMaakunnat, getMaakuntakunnat } from "helpers/maakunnat";
+import {
+  filter,
+  find,
+  includes,
+  map,
+  mapObjIndexed,
+  pathEq,
+  prop,
+  propEq,
+  toUpper
+} from "ramda";
+import { isAdded, isRemoved, isInLupa } from "css/label";
+import kuntaProvinceMapping from "utils/kuntaProvinceMapping";
+
+const labelStyles = {
+  addition: isAdded,
+  removal: isRemoved
+};
+
+const mapping = {
+  "01": "FI-18",
+  "02": "FI-19",
+  "04": "FI-17",
+  "05": "FI-06",
+  "06": "FI-11",
+  "07": "FI-16",
+  "08": "FI-09",
+  "09": "FI-02",
+  "10": "FI-04",
+  "11": "FI-15",
+  "12": "FI-13",
+  "14": "FI-03",
+  "16": "FI-07",
+  "13": "FI-08",
+  "15": "FI-12",
+  "17": "FI-14",
+  "18": "FI-05",
+  "19": "FI-10",
+  "21": "FI-01"
+};
+
+export const getToimintaaluelomake = async (
+  {
+    fiCode,
+    isEditViewActive,
+    changeObjectsByProvince = {},
+    quickFilterChanges = [],
+    localizations,
+    kunnatInLupa,
+    maakunnatInLupa,
+    valtakunnallinenMaarays
+  },
+  booleans,
+  locale,
+  changeObjects,
+  { onChanges, toggleEditView }
 ) => {
+  const kunnat = await getKunnatFromStorage();
+  const maakunnat = await getMaakunnat();
+  const maakuntakunnat = await getMaakuntakunnat();
+
+  const localeUpper = toUpper(locale);
+  const maaraysUuid = valtakunnallinenMaarays.uuid;
+  const options = map(maakunta => {
+    const isMaakuntaInLupa = !!find(province => {
+      return province.metadata.koodiarvo === maakunta.koodiarvo;
+    }, maakunnatInLupa);
+
+    let someMunicipalitiesInLupa = false;
+
+    let someMunicipalitiesNotInLupa = false;
+
+    const today = new Date();
+
+    const presentKunnat = filter(
+      ({ voimassaLoppuPvm }) =>
+        !voimassaLoppuPvm || new Date(voimassaLoppuPvm) >= today,
+      maakunta.kunnat
+    );
+
+    const municipalitiesOfProvince = map(kunta => {
+      const kunnanNimi = kunta.metadata[localeUpper].nimi;
+
+      const isKuntaInLupa = !!find(
+        pathEq(["metadata", "koodiarvo"], kunta.koodiarvo),
+        kunnatInLupa
+      );
+
+      if (isKuntaInLupa) {
+        someMunicipalitiesInLupa = true;
+      } else {
+        someMunicipalitiesNotInLupa = true;
+      }
+
+      return {
+        anchor: kunta.koodiarvo,
+        name: "CheckboxWithLabel",
+        styleClasses: ["w-1/2"],
+        properties: {
+          code: kunta.koodiarvo,
+          forChangeObject: {
+            koodiarvo: kunta.koodiarvo,
+            title: kunnanNimi,
+            maakuntaKey: mapping[maakunta.koodiarvo],
+            maaraysUuid
+          },
+          isChecked: isKuntaInLupa || isMaakuntaInLupa || fiCode === "FI1",
+          labelStyles: Object.assign({}, labelStyles, {
+            custom: isInLupa
+          }),
+          name: kunta.koodiarvo,
+          title: kunnanNimi
+        }
+      };
+    }, presentKunnat);
+
+    const isKuntaOfMaakuntaInLupa = !!find(kunta => {
+      let maakuntaCode;
+      const result = find(
+        k =>
+          propEq("kuntaKoodiarvo", kunta.metadata.koodiarvo, k) &&
+          includes(k.kuntaKoodiarvo, map(prop("koodiarvo"), presentKunnat)),
+        kuntaProvinceMapping
+      );
+      if (result) {
+        mapObjIndexed((value, key) => {
+          if (value === result.maakuntaKey) {
+            maakuntaCode = key;
+          }
+        }, mapping);
+      }
+      return maakuntaCode === maakunta.koodiarvo;
+    }, kunnatInLupa);
+    return {
+      anchor: mapping[maakunta.koodiarvo],
+      formId: mapping[maakunta.koodiarvo],
+      components: [
+        {
+          anchor: "A",
+          name: "CheckboxWithLabel",
+          properties: {
+            code: maakunta.koodiarvo,
+            forChangeObject: {
+              koodiarvo: maakunta.koodiarvo,
+              maakuntaKey: mapping[maakunta.koodiarvo],
+              title: maakunta.label,
+              maaraysUuid
+            },
+            isChecked:
+              fiCode === "FI1" || isMaakuntaInLupa || isKuntaOfMaakuntaInLupa,
+            isIndeterminate:
+              !isMaakuntaInLupa &&
+              someMunicipalitiesInLupa &&
+              someMunicipalitiesNotInLupa,
+            labelStyles: Object.assign({}, labelStyles, {
+              custom: isInLupa
+            }),
+            name: maakunta.koodiarvo,
+            title: maakunta.metadata[localeUpper].nimi
+          }
+        }
+      ],
+      categories: [
+        {
+          anchor: "kunnat",
+          formId: mapping[maakunta.koodiarvo],
+          components: municipalitiesOfProvince
+        }
+      ]
+    };
+  }, maakuntakunnat).filter(Boolean);
+
   return [
     {
       anchor: "valintakentta",
@@ -35,22 +198,3 @@ const getModificationForm = (
     }
   ];
 };
-
-export default function getToimintaaluelomake(action, data) {
-  switch (action) {
-    case "modification":
-      return getModificationForm(
-        data.isEditViewActive,
-        data.changeObjectsByProvince,
-        data.quickFilterChanges,
-        data.options,
-        data.onChanges,
-        data.kunnat,
-        data.maakunnat,
-        data.localizations,
-        data.toggleEditView
-      );
-    default:
-      return [];
-  }
-}

--- a/src/services/muutoshakemus/utils/saving.js
+++ b/src/services/muutoshakemus/utils/saving.js
@@ -23,7 +23,6 @@ export async function createObjectToSave(
 ) {
   const { unsaved } = changeObjects;
 
-  console.info("Opiskelijavuosimuutokset", opiskelijavuodetCO);
   // Adds data that has attachements
   const yhteenvetoYleiset = R.path(
     ["yhteenveto", "yleisettiedot"],
@@ -38,7 +37,7 @@ export async function createObjectToSave(
     changeObjects
   );
   const perustelutLiitteet = R.path(["perustelut", "liitteet"], changeObjects);
-  console.info(changeObjects);
+
   //get actual attachment props
 
   const perustelutLiitteetList =
@@ -401,8 +400,6 @@ export async function createObjectToSave(
       ]).filter(Boolean)
     };
   }
-
-  console.info(objectToSave);
 
   return objectToSave;
 }

--- a/src/stores/lomakedata.js
+++ b/src/stores/lomakedata.js
@@ -1,5 +1,5 @@
 import { createStore, createHook, createContainer } from "react-sweet-state";
-import { assocPath, path, split } from "ramda";
+import { assocPath, path, prepend, split } from "ramda";
 import { recursiveTreeShake } from "utils/common";
 
 const Store = createStore({
@@ -8,7 +8,7 @@ const Store = createStore({
   },
   actions: {
     setLomakedata: (data, anchor) => ({ getState, setState }) => {
-      const anchorParts = split("_", anchor);
+      const anchorParts = prepend("sections", split("_", anchor));
       const nextStateCandidate = assocPath(anchorParts, data, getState());
       const shakedTree = recursiveTreeShake(anchorParts, nextStateCandidate);
       setState(shakedTree);
@@ -21,7 +21,9 @@ const Store = createStore({
 });
 
 const getLomakedataByAnchor = (state, { anchor }) => {
-  return anchor ? path(split("_", anchor), state) || {} : state;
+  return anchor
+    ? path(prepend("sections", split("_", anchor)), state) || {}
+    : state;
 };
 
 export const useValidity = createHook(Store, {
@@ -30,6 +32,10 @@ export const useValidity = createHook(Store, {
 
 export const useLomakedata = createHook(Store, {
   selector: getLomakedataByAnchor
+});
+
+export const useAllSections = createHook(Store, {
+  selector: state => state.sections
 });
 
 export const LomakedataContainer = createContainer(Store, {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -255,16 +255,21 @@ const isBranchEmpty = obj => {
 const isWholeBranchEmpty = obj => R.isEmpty(isBranchEmpty(obj));
 
 const removeOldLeaves = (p = [], tree) => {
-  return R.assocPath(
-    p,
-    R.without(
-      R.filter(leaf => {
-        return R.pathEq(["properties", "deleteElement"], true, leaf);
-      }, R.path(p, tree)),
-      R.path(p, tree)
-    ),
-    tree
-  );
+  const leavesOnBranch = R.path(p, tree);
+  if (Array.isArray(leavesOnBranch)) {
+    return R.assocPath(
+      p,
+      R.without(
+        R.filter(leaf => {
+          return R.pathEq(["properties", "deleteElement"], true, leaf);
+        }, leavesOnBranch),
+        leavesOnBranch
+      ),
+      tree
+    );
+  } else {
+    return tree;
+  }
 };
 
 const protectedTreeProps = ["unsaved", "underRemoval"];
@@ -276,7 +281,7 @@ const protectedTreeProps = ["unsaved", "underRemoval"];
  * @param {*} p Polku, joka käydään läpi aloittaen polun perältä
  * @param {*} branch Objekti (oksa), joka käydään läpi. Voi olla koko puu.
  */
-export const recursiveTreeShake = (p = [], branch, dispatch) => {
+export const recursiveTreeShake = (p = [], branch) => {
   /**
    * Poistetaan käsiteltävänä olevasta oksasta poistettavaksi merkityt lehdet.
    * Toimenpiteen ohessa lehdestä voi löytyä merkintöjä operaatoista, jotka
@@ -301,5 +306,6 @@ export const recursiveTreeShake = (p = [], branch, dispatch) => {
       }
     }
   }
+
   return updatedBranch;
 };


### PR DESCRIPTION
# Olennaisimmat työt

* Siirretty toiminta-alueen vaihtoehtojen listaaminen lomakepalvelun puolelle.
* Korjattu vaativaa tukea koskeva opiskelijamäärän tallentaminen.
* Poistettu turhia parameterjä ja monet turhat konsolitulostukset.

Tämä PR kattaa CSCOIVA-1701 -tiketin lisäksi myös seuraavat tiketit: CSCOIVA-1698, CSCOIVA-1700 ja CSCOIVA-1702. Eli kannattaa katselmoida / testata sekä PO- että ammatillisen koulutuksen lomake.

