### PR TITLE
CSCOIVA-1798: Frontendin npm build rikki

### DIFF
--- a/tailwind.js
+++ b/tailwind.js
@@ -102,8 +102,7 @@ module.exports = {
       "40": "10rem",
       "48": "12rem",
       "56": "14rem",
-      "64": "16rem",
-      inherit: "inherit"
+      "64": "16rem"
     },
     backgroundColor: theme => theme("colors"),
     backgroundPosition: {


### PR DESCRIPTION
* Aja `npm run tailwind:css`, jotta tailwind.css päivittyy ja virheelliset CSS-määritykset poistuvat.