### PR TITLE
CSCOIVA-1847: Mobiilinavigaation navigointi näppäimistöllä

### DIFF
--- a/src/components/02-organisms/Header/MobileMenu/index.js
+++ b/src/components/02-organisms/Header/MobileMenu/index.js
@@ -14,6 +14,20 @@ import { AppRoute } from "const/index";
 import { getKoulutusmuodot, localizeRouteKey } from "../../../../utils/common";
 import AuthenticationLink from "../AuthenticationLink";
 import OrganisationLink from "../OrganisationLink";
+import { Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+  margin: {
+    margin: theme.spacing(1)
+  },
+  root: {
+    marginTop: "0.6rem",
+    paddingLeft: 0,
+    textTransform: "none",
+    color: "#ffffff"
+  }
+}));
 
 const MobileMenu = ({
   localesByLang,
@@ -21,12 +35,10 @@ const MobileMenu = ({
   organisationLink,
   authenticationLink
 }) => {
+  const classes = useStyles();
   const { formatMessage, locale } = useIntl();
   const koulutusmuodot = getKoulutusmuodot(formatMessage);
-  const [
-    jarjestamisluvatMenuVisible,
-    setJarjestamisluvatMenuVisible
-  ] = useState(false);
+  const [jarjestamisluvatMenuVisible] = useState(true);
 
   const AppRouteTitlesMobile = [
     { route: AppRoute.Tilastot, translationKey: "common.statistics" },
@@ -39,49 +51,44 @@ const MobileMenu = ({
 
   return (
     <React.Fragment>
-      <span
-        className="flex-1 flex align-top pt-5 px-5"
-        style={{ height: "4.562rem" }}
-      >
-        <span>
-          <span
-            className="cursor-pointer"
-            style={{ fontSize: "0.9375rem" }}
-            onClick={onCloseMenu}
-          >
-            <img
-              className="mb-1 inline-block"
-              style={{ paddingRight: "0.625rem" }}
-              alt={`${formatMessage(common.sulje)}`}
-              src={close_icon}
-            />
-            {formatMessage(common.sulje)}
-          </span>
-        </span>
+      <span className="flex-1 flex align-top" style={{ height: "4.562rem" }}>
+        <Button
+          className={classes.root}
+          style={{ fontSize: "0.9375rem" }}
+          onClick={onCloseMenu}
+        >
+          <img
+            className="mb-1 inline-block"
+            style={{ paddingRight: "0.625rem" }}
+            alt={`${formatMessage(common.sulje)}`}
+            src={close_icon}
+          />
+          {formatMessage(common.sulje)}
+        </Button>
 
-        <span className="ml-auto">
+        <span className="ml-auto pt-5 px-5">
           <LanguageSwitcher localesByLang={localesByLang} showBorder={false} />
         </span>
       </span>
-      <NavLink to={localizeRouteKey(locale, AppRoute.Home, formatMessage)}>
+      <NavLink
+        to={localizeRouteKey(locale, AppRoute.Home, formatMessage)}
+        className="block"
+      >
         <img
           alt={`${formatMessage(common.opetusJaKulttuuriministerio)} logo`}
           src={locale === "sv" ? logo_sv : logo_fi}
-          className="lg:w-fit-content max-w-sm pb-6 px-5"
+          className="lg:w-fit-content max-w-sm py-6 px-5"
         />
       </NavLink>
       <div className={jarjestamisluvatMenuVisible ? "bg-green-600" : ""}>
         <span
           className="px-5 pt-3 font-medium inline-block"
-          onClick={() =>
-            setJarjestamisluvatMenuVisible(!jarjestamisluvatMenuVisible)
-          }
           style={{
             width: "100%",
             height: "2.875rem"
           }}
         >
-          <div className="cursor-pointer">
+          <div>
             <span style={{ paddingRight: "0.625rem" }}>
               {formatMessage(common.jarjestamisJaYllapitamisluvat)}
             </span>

--- a/src/components/02-organisms/Header/index.js
+++ b/src/components/02-organisms/Header/index.js
@@ -10,12 +10,14 @@ import common from "i18n/definitions/common";
 import { Navigation } from "modules/navigation/index";
 import { LanguageSwitcher } from "modules/i18n/index";
 import MenuIcon from "@material-ui/icons/Menu";
+import { IconButton } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 
 import logo_fi from "static/images/oiva-logo-fi-tekstilla.svg";
 import logo_sv from "static/images/oiva-logo-sv-tekstilla.svg";
 import oiva_logo from "static/images/oiva-logo.svg";
-import MobileMenu from "./MobileMenu";
-import SideNavigation from "../SideNavigation";
+import MobileMenu from "./MobileMenu/index";
+import SideNavigation from "../SideNavigation/index";
 import AuthenticationLink from "./AuthenticationLink";
 import OrganisationLink from "./OrganisationLink";
 
@@ -27,9 +29,20 @@ export const MEDIA_QUERIES = {
   DESKTOP_LARGE: "only screen and (min-width: 1280px)"
 };
 
+const useStyles = makeStyles(theme => ({
+  margin: {
+    margin: theme.spacing(1)
+  },
+  extendedIcon: {
+    color: "#ffffff",
+    marginRight: theme.spacing(1)
+  }
+}));
+
 const Header = ({ localesByLang, authenticationLink, organisationLink }) => {
   const { formatMessage, locale } = useIntl();
   const { pathname } = useLocation();
+  const classes = useStyles();
 
   const breakpointTabletMin = useMediaQuery(MEDIA_QUERIES.TABLET_MIN);
 
@@ -125,11 +138,16 @@ const Header = ({ localesByLang, authenticationLink, organisationLink }) => {
             />
           </SideNavigation>
           <AppBar className="bg-green-500" elevation={0} position="static">
-            <Toolbar className="px-5 justify-start overflow-hidden">
-              <MenuIcon
-                className="mr-6 cursor-pointer"
+            <Toolbar className="justify-start overflow-hidden">
+              <IconButton
+                aria-label="open-main-menu"
+                color="inherit"
                 onClick={toggleMobileMenu}
-              />
+                className={classes.margin}
+              >
+                <MenuIcon />
+              </IconButton>
+
               <NavLink
                 to={localizeRouteKey(locale, AppRoute.Home, formatMessage)}
                 className="flex items-center no-underline text-white hover:text-gray-100 mr-16"
@@ -152,7 +170,6 @@ const Header = ({ localesByLang, authenticationLink, organisationLink }) => {
                   />
                 )}
               </NavLink>
-
               <div className="flex-1 flex justify-end items-center">
                 {mediumSizedScreen && organisationLink.path && (
                   <OrganisationLink


### PR DESCRIPTION
Päädyin ratkaisuun, jossa mobiilivalikon kohta "Järjestämis- ja ylläpitämisluvat" on koko ajan avattuna. Itse pääsivulle "Järjestämis- ja ylläpitämisluvat" ei mobiilivalikosta käsin pääse, mutta se lienee ok viitaten issueen CSCOIVA-1846, jonka kuvauksessa on teksti "erillistä Järjestämis- ja ylläpitämisluvat -päätason sivua näin ollen tarvita".