### PR TITLE
CSCOIVA-1905: Osio 5 määräysten huomioon ottaminen

### DIFF
--- a/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
+++ b/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
@@ -123,7 +123,7 @@ export async function createObjectToSave(
     R.filter(
       maarays =>
         maarays.koodisto === "oivamuutoikeudetvelvollisuudetehdotjatehtavat",
-      lupa.maaraykset
+      lupa.maaraykset || []
     )
   );
 

--- a/src/helpers/lukioErityisetKoulutustehtavat/index.js
+++ b/src/helpers/lukioErityisetKoulutustehtavat/index.js
@@ -191,10 +191,11 @@ export const defineBackendChangeObjects = async (
         const index = nth(2, split(".", changeObj.anchor));
 
         const isValtakunnallinenKehitystehtava = find(
-          compose(
-            endsWith(`.${koodiarvo}.${index}.valintaelementti`),
-            prop("anchor")
-          ),
+          tehtava =>
+            endsWith(
+              `.${koodiarvo}.${index}.valintaelementti`,
+              tehtava.anchor
+            ) && tehtava.tila !== "POISTO",
           changeObjects.valtakunnallisetKehittamistehtavat
         );
 
@@ -239,7 +240,9 @@ export const defineBackendChangeObjects = async (
               changeObj
             )
           },
-          tila: checkboxChangeObj.properties.isChecked ? "LISAYS" : "POISTO"
+          tila: path(["properties", "isChecked", checkboxChangeObj])
+            ? "LISAYS"
+            : "POISTO"
         };
 
         const kuvausnro = getAnchorPart(changeObj.anchor, 2);

--- a/src/helpers/lukioValtakunnallinenKehittamistehtava/index.js
+++ b/src/helpers/lukioValtakunnallinenKehittamistehtava/index.js
@@ -1,10 +1,23 @@
-import { compose, find, flatten, includes, path, prop, propEq } from "ramda";
+import {
+  compose,
+  filter,
+  find,
+  flatten,
+  includes,
+  map,
+  path,
+  pathEq,
+  prop,
+  propEq
+} from "ramda";
+import { getAnchorPart } from "../../utils/common";
 
 export const defineBackendChangeObjects = async (
   changeObjects = [],
   maaraystyypit,
   locale,
-  kohteet
+  kohteet,
+  maaraykset
 ) => {
   const kohde = find(
     propEq("tunniste", "valtakunnallinenkehittamistehtava"),
@@ -22,27 +35,77 @@ export const defineBackendChangeObjects = async (
     changeObjects.valtakunnallisetKehittamistehtavat
   );
 
+  const valintaChangeObjs = filter(
+    compose(includes(".valintaelementti"), prop("anchor")),
+    changeObjects.valtakunnallisetKehittamistehtavat
+  );
+
+  const valtakunnallinenkehittamistehtavaMaaraykset = filter(
+    maarays =>
+      propEq("koodisto", "valtakunnallinenkehittamistehtava") &&
+      pathEq(
+        ["kohde", "tunniste"],
+        "valtakunnallinenkehittamistehtava",
+        maarays
+      ),
+    maaraykset || []
+  );
+
+  const valintaBeChangeObjects = map(changeObj => {
+    const koodiarvo = getAnchorPart(changeObj.anchor, 1);
+    const ankkuri = getAnchorPart(changeObj.anchor, 2);
+    const tila = path(["properties", "isChecked"], changeObj)
+      ? "LISAYS"
+      : "POISTO";
+    const maaraysUuid =
+      tila === "POISTO"
+        ? prop(
+            "uuid",
+            find(
+              maarays =>
+                propEq("koodiarvo", koodiarvo, maarays) &&
+                pathEq(["meta", "ankkuri"], ankkuri, maarays),
+              valtakunnallinenkehittamistehtavaMaaraykset
+            )
+          )
+        : null;
+    return {
+      generatedId: changeObj.anchor,
+      kohde,
+      koodiarvo: koodiarvo,
+      koodisto: kohde.tunniste,
+      maaraystyyppi,
+      maaraysUuid,
+      meta: {
+        ankkuri,
+        isChecked: path(["properties", "checked"], changeObj),
+        changeObjects: flatten([changeObj]).filter(Boolean)
+      },
+      tila
+    };
+  }, valintaChangeObjs || []);
+
   const lisatiedotBEchangeObject = lisatiedotChangeObj
     ? {
-      kohde,
-      koodiarvo: path(
-        ["properties", "metadata", "koodiarvo"],
-        lisatiedotChangeObj
-      ),
-      koodisto: path(
-        ["properties", "metadata", "koodisto", "koodistoUri"],
-        lisatiedotChangeObj
-      ),
-      maaraystyyppi,
-      meta: {
-        arvo: path(["properties", "value"], lisatiedotChangeObj),
-        changeObjects: [lisatiedotChangeObj]
-      },
-      tila: "LISAYS"
-    }
+        kohde,
+        koodiarvo: path(
+          ["properties", "metadata", "koodiarvo"],
+          lisatiedotChangeObj
+        ),
+        koodisto: path(
+          ["properties", "metadata", "koodisto", "koodistoUri"],
+          lisatiedotChangeObj
+        ),
+        maaraystyyppi,
+        meta: {
+          arvo: path(["properties", "value"], lisatiedotChangeObj),
+          changeObjects: [lisatiedotChangeObj]
+        },
+        tila: "LISAYS"
+      }
     : null;
 
-  return flatten([lisatiedotBEchangeObject]).filter(
+  return flatten([valintaBeChangeObjects, lisatiedotBEchangeObject]).filter(
     Boolean
   );
 };

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/lupanakymat/LupanakymaA.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/lupanakymat/LupanakymaA.js
@@ -177,7 +177,6 @@ const LupanakymaA = React.memo(
       rajoitteet
     );
 
-
     const valtakunnallisetKehittamistehtavatRajoitteet = getRajoitteetBySection(
       "valtakunnallisetKehittamistehtavat",
       rajoitteet
@@ -273,9 +272,14 @@ const LupanakymaA = React.memo(
                   <ValtakunnallisetKehittamistehtavat
                     code="5"
                     isPreviewModeOn={isPreviewModeOn}
-                    maaraykset={filterByTunniste(
-                      "valtakunnallinenKehittamistehtava",
-                      maaraykset
+                    maaraykset={filter(
+                      maarays =>
+                        propEq(
+                          "koodisto",
+                          "valtakunnallinenkehittamistehtava",
+                          maarays
+                        ),
+                      maaraykset || []
                     )}
                     rajoitteet={valtakunnallisetKehittamistehtavatRajoitteet}
                     sectionId={"valtakunnallisetKehittamistehtavat"}

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/saving.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/saving.js
@@ -189,7 +189,8 @@ export async function createObjectToSave(
     },
     maaraystyypit,
     locale,
-    kohteet
+    kohteet,
+    lupa.maaraykset
   );
 
   // 6. OPPILAS-/OPISKELIJAMÄÄRÄT

--- a/src/services/lomakkeet/lukiokoulutus/4-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/lukiokoulutus/4-erityisetKoulutustehtavat.js
@@ -44,12 +44,12 @@ export async function getErityisetKoulutustehtavatLukio(
   return flatten(
     [
       map(erityinenKoulutustehtava => {
-        const tehtavaanLiittyvatMaaraykset = filter(
-          m =>
-            propEq("koodiarvo", erityinenKoulutustehtava.koodiarvo, m) &&
-            propEq("koodisto", "lukioerityinenkoulutustehtavauusi", m),
-          maaraykset
-        );
+        const tehtavaanLiittyvatMaaraykset = filter(m => {
+          return (
+            m.koodiarvo == erityinenKoulutustehtava.koodiarvo &&
+            propEq("koodisto", "lukioerityinenkoulutustehtavauusi", m)
+          );
+        }, maaraykset);
         const kuvausmaaraykset = filter(
           hasPath(["meta", "kuvaus"]),
           tehtavaanLiittyvatMaaraykset
@@ -84,7 +84,6 @@ export async function getErityisetKoulutustehtavatLukio(
           pathEq(["meta", "ankkuri"], kuvausankkuri0),
           kuvausmaaraykset
         );
-
         return {
           anchor: erityinenKoulutustehtava.koodiarvo,
           categories: flatten([

--- a/src/services/lomakkeet/lukiokoulutus/5-valtakunnallinenKehittamistehtava.js
+++ b/src/services/lomakkeet/lukiokoulutus/5-valtakunnallinenKehittamistehtava.js
@@ -33,10 +33,19 @@ export async function getValtakunnallinenKehittamistehtavalomake(
     }
   ];
   if (checkboxStatesSection4.length > 0) {
-    kehittamistehtavatStructure = flatten(concat(kehittamistehtavatStructure,
-      [
+    kehittamistehtavatStructure = flatten(
+      concat(kehittamistehtavatStructure, [
         map(checkboxObjSection4 => {
-          const anchor = `${getAnchorPart(checkboxObjSection4.anchor, 1)}.${getAnchorPart(checkboxObjSection4.anchor, 2)}`;
+          const koodiarvo = getAnchorPart(checkboxObjSection4.anchor, 1);
+          const kuvausNro = getAnchorPart(checkboxObjSection4.anchor, 2);
+          const maaraysForCheckbox = find(
+            maarays =>
+              maarays.koodiarvo === koodiarvo &&
+              path(["meta", "ankkuri"], maarays) === kuvausNro,
+            maaraykset
+          );
+
+          const anchor = `${koodiarvo}.${kuvausNro}`;
           return {
             anchor,
             components: [
@@ -44,7 +53,7 @@ export async function getValtakunnallinenKehittamistehtavalomake(
                 anchor: "valintaelementti",
                 name: "CheckboxWithLabel",
                 properties: {
-                  isChecked: path(["properties", "metadata", "isChecked"], checkboxObjSection4),
+                  isChecked: !!maaraysForCheckbox,
                   isIndeterminate: false,
                   isPreviewModeOn,
                   isReadOnly: _isReadOnly,
@@ -58,39 +67,43 @@ export async function getValtakunnallinenKehittamistehtavalomake(
             ]
           };
         }, checkboxStatesSection4)
-      ]));
+      ])
+    );
   } else {
-    kehittamistehtavatStructure = flatten(concat(kehittamistehtavatStructure, [{
-      anchor: "info",
+    kehittamistehtavatStructure = flatten(
+      concat(kehittamistehtavatStructure, [
+        {
+          anchor: "info",
+          components: [
+            {
+              anchor: "valinta",
+              name: "StatusTextRow",
+              properties: {
+                title: __("education.valtakunnallinenKehittamistehtavaInfo2")
+              }
+            }
+          ]
+        }
+      ])
+    );
+  }
+  let lisatiedotStructure = flatten([
+    {
+      anchor: "valtakunnalliset-kehittamistehtavat",
+      layout: { margins: { top: "large" } },
       components: [
         {
-          anchor: "valinta",
+          anchor: "lisatiedot-info",
           name: "StatusTextRow",
+          styleClasses: ["pt-8", "border-t"],
           properties: {
-            title: __("education.valtakunnallinenKehittamistehtavaInfo2")
+            title: __("common.lisatiedotInfo")
           }
         }
       ]
-    }]));
-  }
-  let lisatiedotStructure = flatten(
-    [
-      {
-        anchor: "valtakunnalliset-kehittamistehtavat",
-        layout: { margins: { top: "large" } },
-        components: [
-          {
-            anchor: "lisatiedot-info",
-            name: "StatusTextRow",
-            styleClasses: ["pt-8", "border-t"],
-            properties: {
-              title: __("common.lisatiedotInfo")
-            }
-          }
-        ]
-      },
-      lisatiedotObj
-        ? {
+    },
+    lisatiedotObj
+      ? {
           anchor: "lisatiedot",
           components: [
             {
@@ -111,9 +124,10 @@ export async function getValtakunnallinenKehittamistehtavalomake(
             }
           ]
         }
-        : null
-    ]
-  );
+      : null
+  ]);
 
-  return flatten([kehittamistehtavatStructure, lisatiedotStructure]).filter(Boolean);
+  return flatten([kehittamistehtavatStructure, lisatiedotStructure]).filter(
+    Boolean
+  );
 }


### PR DESCRIPTION
-Luodaan osiolle 5 omat muutos-objektit sekä määräykset (aiemmin menivät vain 4 osion muutosten mukana metassa)
-Huomioidaan osion 4 määräysten poistaminen ja luodaan näiden perusteella tarvittaessa poisto-objekteja.