### PR TITLE
CSCOIVA-1960: Lukiolomake: "Opetusta järjestetään suomen…

### DIFF
--- a/src/services/lomakkeet/lukiokoulutus/esikatselu/1-opetustaAntavatKunnat.js
+++ b/src/services/lomakkeet/lukiokoulutus/esikatselu/1-opetustaAntavatKunnat.js
@@ -53,7 +53,7 @@ export async function previewOfOpetustaAntavaKunnat({
   );
 
   const ulkomaaTextBoxes = filter(
-    compose(endsWith(".lisatiedot"), prop("anchor")),
+    compose(endsWith(".kuvaus"), prop("anchor")),
     lomakedata
   );
 


### PR DESCRIPTION
 ulkopuolella" ei näy esikatselussa