### PR TITLE
CSCOIVA-1994: -Dynaamisten tekstikenttien tallennus toimimaan oikein

### DIFF
--- a/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
+++ b/src/helpers/ammatillinenKoulutus/tallentaminen/esittelijat.js
@@ -123,7 +123,7 @@ export async function createObjectToSave(
     R.filter(
       maarays =>
         maarays.koodisto === "oivamuutoikeudetvelvollisuudetehdotjatehtavat",
-      lupa.maaraykset
+      lupa.maaraykset || []
     )
   );
 

--- a/src/helpers/lukioMuutEhdot/index.js
+++ b/src/helpers/lukioMuutEhdot/index.js
@@ -26,7 +26,7 @@ import localforage from "localforage";
 import { createMaarayksiaVastenLuodutRajoitteetDynaamisilleTekstikentilleBEObjects } from "../../utils/rajoitteetUtils";
 import {
   createDynamicTextBoxBeChangeObjects,
-  createDynamicTextBoxBeCheckboxChangeObjects
+  createBECheckboxChangeObjectsForDynamicTextBoxes
 } from "../../services/lomakkeet/dynamic";
 
 export const initializeLukioMuuEhto = ehto => {
@@ -149,7 +149,7 @@ export const defineBackendChangeObjects = async (
         kohteet
       );
     } else {
-      return createDynamicTextBoxBeCheckboxChangeObjects(
+      return createBECheckboxChangeObjectsForDynamicTextBoxes(
         checkboxChangeObj,
         ehto,
         rajoitteetByRajoiteIdAndKoodiarvo,

--- a/src/helpers/lukioMuutEhdot/index.js
+++ b/src/helpers/lukioMuutEhdot/index.js
@@ -1,7 +1,5 @@
 import {
   compose,
-  concat,
-  drop,
   endsWith,
   filter,
   find,
@@ -9,27 +7,27 @@ import {
   groupBy,
   head,
   includes,
-  isEmpty,
   isNil,
   length,
   map,
   mapObjIndexed,
-  nth,
   omit,
   path,
+  pathEq,
   prop,
   propEq,
   reject,
   sort,
-  split,
   startsWith,
-  take,
-  values
+  toUpper
 } from "ramda";
-import { getMaarayksetByTunniste} from "../lupa/index";
+import { getMaarayksetByTunniste } from "../lupa/index";
 import localforage from "localforage";
-import { createAlimaarayksetBEObjects } from "helpers/rajoitteetHelper";
 import { createMaarayksiaVastenLuodutRajoitteetDynaamisilleTekstikentilleBEObjects } from "../../utils/rajoitteetUtils";
+import {
+  createDynamicTextBoxBeChangeObjects,
+  createDynamicTextBoxBeCheckboxChangeObjects
+} from "../../services/lomakkeet/dynamic";
 
 export const initializeLukioMuuEhto = ehto => {
   return omit(["koodiArvo"], {
@@ -73,7 +71,7 @@ export const defineBackendChangeObjects = async (
   const maaraykset = await getMaarayksetByTunniste(
     "muutkoulutuksenjarjestamiseenliittyvatehdot",
     lupaMaaraykset
-  )
+  );
 
   const { rajoitteetByRajoiteId } = changeObjects;
 
@@ -115,104 +113,55 @@ export const defineBackendChangeObjects = async (
       }, rajoitteetByRajoiteId)
     );
 
-    if (length(kuvausChangeObjects)) {
-      kuvausBEchangeObjects = map(changeObj => {
-        const ankkuri = path(["properties", "metadata", "ankkuri"], changeObj);
-        const kuvausBEChangeObject = {
-          generatedId: changeObj.anchor,
-          kohde,
-          koodiarvo: ehto.koodiarvo,
-          koodisto: ehto.koodisto.koodistoUri,
-          kuvaus: changeObj.properties.value,
-          maaraystyyppi,
-          meta: {
-            ankkuri,
-            kuvaus: changeObj.properties.value,
-            changeObjects: flatten(
-              concat(take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)), [
-                checkboxChangeObj,
-                changeObj
-              ])
-            ).filter(Boolean)
-          },
-          tila: path(["properties", "isChecked"], checkboxChangeObj)
-            ? "LISAYS"
-            : "POISTO"
-        };
+    const ehtoonLiittyvatMaaraykset = filter(
+      m =>
+        propEq("koodiarvo", ehto.koodiarvo, m) &&
+        propEq(
+          "koodisto",
+          "lukiomuutkoulutuksenjarjestamiseenliittyvatehdot",
+          m
+        ),
+      maaraykset
+    );
 
-        let alimaaraykset = [];
+    const isCheckboxChecked =
+      (!!ehtoonLiittyvatMaaraykset.length && !checkboxChangeObj) ||
+      (checkboxChangeObj &&
+        pathEq(["properties", "isChecked"], true, checkboxChangeObj));
 
-        const kohteenTarkentimenArvo = path(
-          [1, "properties", "value", "value"],
-          head(values(rajoitteetByRajoiteIdAndKoodiarvo))
-        );
+    const kuvausKoodistosta = path(
+      ["metadata", locale ? toUpper(locale) : "FI", "kuvaus"],
+      find(koodi => koodi.koodiarvo === ehto.koodiarvo, muutEhdot || [])
+    );
 
-        const rajoitevalinnanAnkkuriosa = kohteenTarkentimenArvo
-          ? nth(1, split("-", kohteenTarkentimenArvo))
-          : null;
-
-        if (
-          kohteenTarkentimenArvo &&
-          (rajoitevalinnanAnkkuriosa === ankkuri || !rajoitevalinnanAnkkuriosa)
-        ) {
-          // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
-          // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
-          // loput toisiinsa "alenevassa polvessa".
-          alimaaraykset = values(
-            mapObjIndexed(asetukset => {
-              return createAlimaarayksetBEObjects(
-                kohteet,
-                maaraystyypit,
-                kuvausBEChangeObject,
-                drop(2, asetukset)
-              );
-            }, rajoitteetByRajoiteIdAndKoodiarvo)
-          );
-        }
-
-        return [kuvausBEChangeObject, alimaaraykset];
-      }, kuvausChangeObjects);
+    if (length(kuvausChangeObjects) && isCheckboxChecked) {
+      kuvausBEchangeObjects = createDynamicTextBoxBeChangeObjects(
+        kuvausChangeObjects,
+        ehtoonLiittyvatMaaraykset,
+        kuvausKoodistosta,
+        isCheckboxChecked,
+        ehto,
+        maaraystyyppi,
+        maaraystyypit,
+        rajoitteetByRajoiteIdAndKoodiarvo,
+        checkboxChangeObj,
+        kohde,
+        kohteet
+      );
     } else {
-      // Jos muokattuja kuvauksia ei kyseiselle koodiarvolle löydy, tarkistetaan
-      // löytyykö checkbox-muutos. Jos löytyy, niin luodaan sille backend-muotoinen
-      // muutosobjekti.
-      checkboxBEchangeObject = checkboxChangeObj
-        ? {
-            generatedId: `muuEhto-${Math.random()}`,
-            kohde,
-            koodiarvo: ehto.koodiarvo,
-            koodisto: ehto.koodisto.koodistoUri,
-            kuvaus: ehto.metadata[locale].kuvaus,
-            maaraystyyppi,
-            meta: {
-              changeObjects: flatten(
-                concat(take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)), [
-                  checkboxChangeObj
-                ])
-              ).filter(Boolean)
-            },
-            tila: checkboxChangeObj.properties.isChecked ? "LISAYS" : "POISTO"
-          }
-        : null;
-
-      // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
-      // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
-      // loput toisiinsa "alenevassa polvessa".
-      const alimaaraykset =
-        checkboxBEchangeObject && !isEmpty(rajoitteetByRajoiteIdAndKoodiarvo)
-          ? values(
-              mapObjIndexed(asetukset => {
-                return createAlimaarayksetBEObjects(
-                  kohteet,
-                  maaraystyypit,
-                  checkboxBEchangeObject,
-                  drop(2, asetukset)
-                );
-              }, rajoitteetByRajoiteIdAndKoodiarvo)
-            )
-          : null;
-
-      return [checkboxBEchangeObject, alimaaraykset];
+      return createDynamicTextBoxBeCheckboxChangeObjects(
+        checkboxChangeObj,
+        ehto,
+        rajoitteetByRajoiteIdAndKoodiarvo,
+        kohteet,
+        kohde,
+        maaraystyypit,
+        maaraystyyppi,
+        ehtoonLiittyvatMaaraykset,
+        isCheckboxChecked,
+        locale,
+        "muuEhto"
+      );
     }
 
     return [checkboxBEchangeObject, kuvausBEchangeObjects];
@@ -256,9 +205,11 @@ export const defineBackendChangeObjects = async (
     kohde
   );
 
-  const objects = flatten([maarayksiaVastenLuodutRajoitteet, muutokset, lisatiedotBEchangeObject]).filter(
-    Boolean
-  );
+  const objects = flatten([
+    maarayksiaVastenLuodutRajoitteet,
+    muutokset,
+    lisatiedotBEchangeObject
+  ]).filter(Boolean);
 
   return objects;
 };

--- a/src/helpers/poErityisetKoulutustehtavat/index.js
+++ b/src/helpers/poErityisetKoulutustehtavat/index.js
@@ -1,7 +1,5 @@
 import {
   compose,
-  concat,
-  drop,
   endsWith,
   filter,
   find,
@@ -9,12 +7,10 @@ import {
   groupBy,
   head,
   includes,
-  isEmpty,
   isNil,
   length,
   map,
   mapObjIndexed,
-  nth,
   omit,
   path,
   pathEq,
@@ -22,16 +18,16 @@ import {
   propEq,
   reject,
   sort,
-  split,
   startsWith,
-  take,
-  values
+  toUpper
 } from "ramda";
 import localforage from "localforage";
-import { createAlimaarayksetBEObjects } from "helpers/rajoitteetHelper";
-import { getAnchorPart } from "../../utils/common";
 import { createMaarayksiaVastenLuodutRajoitteetDynaamisilleTekstikentilleBEObjects } from "../../utils/rajoitteetUtils";
 import { getMaarayksetByTunniste } from "../lupa";
+import {
+  createDynamicTextBoxBeChangeObjects,
+  createDynamicTextBoxBeCheckboxChangeObjects
+} from "../../services/lomakkeet/dynamic";
 
 export const initializePOErityinenKoulutustehtava = erityinenKoulutustehtava => {
   return omit(["koodiArvo"], {
@@ -133,113 +129,42 @@ export const defineBackendChangeObjects = async (
       (checkboxChangeObj &&
         pathEq(["properties", "isChecked"], true, checkboxChangeObj));
 
-    if (length(kuvausChangeObjects)) {
-      kuvausBEchangeObjects = map(changeObj => {
-        const ankkuri = path(["properties", "metadata", "ankkuri"], changeObj);
-        const kuvausBEChangeObject = {
-          generatedId: changeObj.anchor,
-          kohde,
-          koodiarvo: koulutustehtava.koodiarvo,
-          koodisto: koulutustehtava.koodisto.koodistoUri,
-          kuvaus: changeObj.properties.value,
-          maaraystyyppi,
-          meta: {
-            ankkuri,
-            kuvaus: changeObj.properties.value,
-            changeObjects: concat(
-              take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)),
-              [checkboxChangeObj, changeObj]
-            ).filter(Boolean)
-          },
-          tila: isCheckboxChecked ? "LISAYS" : "POISTO"
-        };
+    const kuvausKoodistosta = path(
+      ["metadata", locale ? toUpper(locale) : "FI", "kuvaus"],
+      find(
+        koodi => koodi.koodiarvo === koulutustehtava.koodiarvo,
+        erityisetKoulutustehtavat || []
+      )
+    );
 
-        let alimaaraykset = [];
-        const kuvausnro = getAnchorPart(changeObj.anchor, 2);
-        const rajoitteetForKuvaus = filter(rajoiteCobjs => {
-          return (
-            nth(
-              1,
-              split(
-                "-",
-                path([1, "properties", "value", "value"], rajoiteCobjs) || ""
-              )
-            ) === kuvausnro
-          );
-        }, values(rajoitteetByRajoiteIdAndKoodiarvo));
-
-        // TODO: Tässä pitäisi käydä kaikki rajoitteet läpi, jos halutaan useampia
-        // TODO: rajoitteita samalle asialle. (nyt haetaan vain ensimmäisen rajoitteen arvo)
-        const kohteenTarkentimenArvo = path(
-          [1, "properties", "value", "value"],
-          head(rajoitteetForKuvaus)
-        );
-
-        const rajoitevalinnanAnkkuriosa = kohteenTarkentimenArvo
-          ? nth(1, split("-", kohteenTarkentimenArvo))
-          : null;
-
-        if (
-          kohteenTarkentimenArvo &&
-          (rajoitevalinnanAnkkuriosa === ankkuri || !rajoitevalinnanAnkkuriosa)
-        ) {
-          // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
-          // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
-          // loput toisiinsa "alenevassa polvessa".
-          alimaaraykset = values(
-            mapObjIndexed(asetukset => {
-              return createAlimaarayksetBEObjects(
-                kohteet,
-                maaraystyypit,
-                kuvausBEChangeObject,
-                drop(2, asetukset)
-              );
-            }, rajoitteetForKuvaus)
-          );
-        }
-
-        return [kuvausBEChangeObject, alimaaraykset];
-      }, kuvausChangeObjects);
+    if (length(kuvausChangeObjects) && isCheckboxChecked) {
+      kuvausBEchangeObjects = createDynamicTextBoxBeChangeObjects(
+        kuvausChangeObjects,
+        tehtavaanLiittyvatMaaraykset,
+        kuvausKoodistosta,
+        isCheckboxChecked,
+        koulutustehtava,
+        maaraystyyppi,
+        maaraystyypit,
+        rajoitteetByRajoiteIdAndKoodiarvo,
+        checkboxChangeObj,
+        kohde,
+        kohteet
+      );
     } else {
-      // Jos muokattuja kuvauksia ei kyseiselle koodiarvolle löydy, tarkistetaan
-      // löytyykö checkbox-muutos. Jos löytyy, niin luodaan sille backend-muotoinen
-      // muutosobjekti.
-      checkboxBEchangeObject = checkboxChangeObj
-        ? {
-            generatedId: `erityinenKoulutustehtava-${Math.random()}`,
-            kohde,
-            koodiarvo: koulutustehtava.koodiarvo,
-            koodisto: koulutustehtava.koodisto.koodistoUri,
-            kuvaus: koulutustehtava.metadata[locale].kuvaus,
-            maaraystyyppi,
-            meta: {
-              changeObjects: concat(
-                take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)),
-                [checkboxChangeObj]
-              ).filter(Boolean)
-            },
-            tila: checkboxChangeObj.properties.isChecked ? "LISAYS" : "POISTO"
-          }
-        : null;
-
-      // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
-      // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
-      // loput toisiinsa "alenevassa polvessa".
-      const alimaaraykset =
-        checkboxBEchangeObject && !isEmpty(rajoitteetByRajoiteIdAndKoodiarvo)
-          ? values(
-              mapObjIndexed(asetukset => {
-                return createAlimaarayksetBEObjects(
-                  kohteet,
-                  maaraystyypit,
-                  checkboxBEchangeObject,
-                  drop(2, asetukset)
-                );
-              }, rajoitteetByRajoiteIdAndKoodiarvo)
-            )
-          : null;
-
-      return [checkboxBEchangeObject, alimaaraykset];
+      return createDynamicTextBoxBeCheckboxChangeObjects(
+        checkboxChangeObj,
+        koulutustehtava,
+        rajoitteetByRajoiteIdAndKoodiarvo,
+        kohteet,
+        kohde,
+        maaraystyypit,
+        maaraystyyppi,
+        tehtavaanLiittyvatMaaraykset,
+        isCheckboxChecked,
+        locale,
+        "erityinenKoulutustehtava"
+      );
     }
 
     return [checkboxBEchangeObject, kuvausBEchangeObjects];

--- a/src/helpers/poErityisetKoulutustehtavat/index.js
+++ b/src/helpers/poErityisetKoulutustehtavat/index.js
@@ -26,7 +26,7 @@ import { createMaarayksiaVastenLuodutRajoitteetDynaamisilleTekstikentilleBEObjec
 import { getMaarayksetByTunniste } from "../lupa";
 import {
   createDynamicTextBoxBeChangeObjects,
-  createDynamicTextBoxBeCheckboxChangeObjects
+  createBECheckboxChangeObjectsForDynamicTextBoxes
 } from "../../services/lomakkeet/dynamic";
 
 export const initializePOErityinenKoulutustehtava = erityinenKoulutustehtava => {
@@ -152,7 +152,7 @@ export const defineBackendChangeObjects = async (
         kohteet
       );
     } else {
-      return createDynamicTextBoxBeCheckboxChangeObjects(
+      return createBECheckboxChangeObjectsForDynamicTextBoxes(
         checkboxChangeObj,
         koulutustehtava,
         rajoitteetByRajoiteIdAndKoodiarvo,

--- a/src/helpers/poMuutEhdot/index.js
+++ b/src/helpers/poMuutEhdot/index.js
@@ -26,7 +26,7 @@ import { createMaarayksiaVastenLuodutRajoitteetDynaamisilleTekstikentilleBEObjec
 import { getMaarayksetByTunniste } from "../lupa";
 import {
   createDynamicTextBoxBeChangeObjects,
-  createDynamicTextBoxBeCheckboxChangeObjects
+  createBECheckboxChangeObjectsForDynamicTextBoxes
 } from "../../services/lomakkeet/dynamic";
 
 export const initializePOMuuEhto = ehto => {
@@ -152,7 +152,7 @@ export const defineBackendChangeObjects = async (
         kohteet
       );
     } else {
-      return createDynamicTextBoxBeCheckboxChangeObjects(
+      return createBECheckboxChangeObjectsForDynamicTextBoxes(
         checkboxChangeObj,
         ehto,
         rajoitteetByRajoiteIdAndKoodiarvo,

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
@@ -43,7 +43,7 @@ export default function PoOpetuksenErityisetKoulutustehtavatHtml({
   }, []);
 
   const erityisetKoulutustehtavatMaaraykset = sortBy(
-    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    m => parseFloat(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`),
     filter(
       maarays =>
         pathEq(["kohde", "tunniste"], "erityinenkoulutustehtava", maarays) &&

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
@@ -9,6 +9,7 @@ import {
   path,
   pathEq,
   propEq,
+  sortBy,
   toUpper
 } from "ramda";
 import { useIntl } from "react-intl";
@@ -41,11 +42,14 @@ export default function PoOpetuksenErityisetKoulutustehtavatHtml({
       });
   }, []);
 
-  const erityisetKoulutustehtavatMaaraykset = filter(
-    maarays =>
-      pathEq(["kohde", "tunniste"], "erityinenkoulutustehtava", maarays) &&
-      maarays.koodisto === "poerityinenkoulutustehtava",
-    maaraykset
+  const erityisetKoulutustehtavatMaaraykset = sortBy(
+    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    filter(
+      maarays =>
+        pathEq(["kohde", "tunniste"], "erityinenkoulutustehtava", maarays) &&
+        maarays.koodisto === "poerityinenkoulutustehtava",
+      maaraykset
+    )
   );
 
   const lisatietomaarays = find(

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
@@ -36,7 +36,7 @@ export default function PoOpetuksenMuutEhdotHtml({ maaraykset }) {
   }, []);
 
   const muutEhdotMaaraykset = sortBy(
-    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    m => parseFloat(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`),
     filter(
       maarays =>
         pathEq(

--- a/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
+++ b/src/scenes/Koulutusmuodot/EsiJaPerusopetus/JarjestamislupaHTML/muutEhdot.js
@@ -9,6 +9,7 @@ import {
   path,
   pathEq,
   propEq,
+  sortBy,
   toUpper
 } from "ramda";
 import { useIntl } from "react-intl";
@@ -34,14 +35,18 @@ export default function PoOpetuksenMuutEhdotHtml({ maaraykset }) {
       });
   }, []);
 
-  const muutEhdotMaaraykset = filter(
-    maarays =>
-      pathEq(
-        ["kohde", "tunniste"],
-        "muutkoulutuksenjarjestamiseenliittyvatehdot",
-        maarays
-      ) && maarays.koodisto === "pomuutkoulutuksenjarjestamiseenliittyvatehdot",
-    maaraykset
+  const muutEhdotMaaraykset = sortBy(
+    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    filter(
+      maarays =>
+        pathEq(
+          ["kohde", "tunniste"],
+          "muutkoulutuksenjarjestamiseenliittyvatehdot",
+          maarays
+        ) &&
+        maarays.koodisto === "pomuutkoulutuksenjarjestamiseenliittyvatehdot",
+      maaraykset
+    )
   );
 
   const lisatietomaarays = find(

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
@@ -40,7 +40,7 @@ export default function ErityisetKoulutustehtavatHtml({ maaraykset }) {
   }, []);
 
   const erityisetKoulutustehtavatMaaraykset = sortBy(
-    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    m => parseFloat(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`),
     filter(
       maarays =>
         maarays.kohde.tunniste === "erityinenkoulutustehtava" &&

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/erityisetKoulutustehtavat.js
@@ -9,6 +9,7 @@ import {
   map,
   path,
   propEq,
+  sortBy,
   toUpper
 } from "ramda";
 import { useIntl } from "react-intl";
@@ -38,11 +39,14 @@ export default function ErityisetKoulutustehtavatHtml({ maaraykset }) {
       });
   }, []);
 
-  const erityisetKoulutustehtavatMaaraykset = filter(
-    maarays =>
-      maarays.kohde.tunniste === "erityinenkoulutustehtava" &&
-      maarays.koodisto === "lukioerityinenkoulutustehtavauusi",
-    maaraykset
+  const erityisetKoulutustehtavatMaaraykset = sortBy(
+    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    filter(
+      maarays =>
+        maarays.kohde.tunniste === "erityinenkoulutustehtava" &&
+        maarays.koodisto === "lukioerityinenkoulutustehtavauusi",
+      maaraykset
+    )
   );
 
   const lisatietomaarays = find(

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/muutEhdot.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/muutEhdot.js
@@ -34,7 +34,7 @@ export default function OpetuksenMuutEhdotHtml({ maaraykset }) {
   }, []);
 
   const muutEhdotMaaraykset = sortBy(
-    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    m => parseFloat(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`),
     filter(
       maarays =>
         maarays.kohde.tunniste ===

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/muutEhdot.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/muutEhdot.js
@@ -8,6 +8,7 @@ import {
   map,
   path,
   propEq,
+  sortBy,
   toUpper
 } from "ramda";
 import { useIntl } from "react-intl";
@@ -32,12 +33,15 @@ export default function OpetuksenMuutEhdotHtml({ maaraykset }) {
       });
   }, []);
 
-  const muutEhdotMaaraykset = filter(
-    maarays =>
-      maarays.kohde.tunniste ===
-        "muutkoulutuksenjarjestamiseenliittyvatehdot" &&
-      maarays.koodisto === "lukiomuutkoulutuksenjarjestamiseenliittyvatehdot",
-    maaraykset
+  const muutEhdotMaaraykset = sortBy(
+    m => parseInt(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`, 10),
+    filter(
+      maarays =>
+        maarays.kohde.tunniste ===
+          "muutkoulutuksenjarjestamiseenliittyvatehdot" &&
+        maarays.koodisto === "lukiomuutkoulutuksenjarjestamiseenliittyvatehdot",
+      maaraykset
+    )
   );
 
   const lisatietomaarays = find(

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/valtakunnallisetKehittamistehtavat.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/JarjestamislupaHTML/valtakunnallisetKehittamistehtavat.js
@@ -9,6 +9,7 @@ import {
   map,
   path,
   propEq,
+  sortBy,
   toUpper
 } from "ramda";
 import { useIntl } from "react-intl";
@@ -38,12 +39,15 @@ export default function ValtakunnallisetKehittamistehtavatHtml({ maaraykset }) {
       });
   }, []);
 
-  const valtakunnallisetKehittamistehtavatMaaraykset = filter(
-    maarays =>
-      maarays.kohde.tunniste === "erityinenkoulutustehtava" &&
-      maarays.koodisto === "lukioerityinenkoulutustehtavauusi" &&
-      maarays.meta.isValtakunnallinenKehitystehtava,
-    maaraykset
+  const valtakunnallisetKehittamistehtavatMaaraykset = sortBy(
+    m => parseFloat(`${m.koodiarvo}.${path(["meta", "ankkuri"], m)}`),
+    filter(
+      maarays =>
+        maarays.kohde.tunniste === "erityinenkoulutustehtava" &&
+        maarays.koodisto === "lukioerityinenkoulutustehtavauusi" &&
+        maarays.meta.isValtakunnallinenKehitystehtava,
+      maaraykset
+    )
   );
 
   const lisatietomaarays = find(

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/lomakeosiot/5-ValtakunnallisetKehittamistehtavat.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/lomakeosiot/5-ValtakunnallisetKehittamistehtavat.js
@@ -5,7 +5,17 @@ import Lomake from "components/02-organisms/Lomake";
 import education from "i18n/definitions/education";
 import { useChangeObjectsByAnchorWithoutUnderRemoval } from "stores/muutokset";
 import { useLomakedata } from "stores/lomakedata";
-import { compose, filter, prop, propEq, map, startsWith, allPass, endsWith, flatten } from "ramda";
+import {
+  compose,
+  filter,
+  prop,
+  propEq,
+  map,
+  startsWith,
+  allPass,
+  endsWith,
+  flatten
+} from "ramda";
 
 const constants = {
   formLocation: ["lukiokoulutus", "valtakunnallinenKehittamistehtava"],
@@ -32,18 +42,22 @@ const ValtakunnallisetKehittamistehtavat = ({
     anchor: "erityisetKoulutustehtavat"
   });
 
-   useEffect(() => {
-    let items = flatten(map(item => {
+  useEffect(() => {
+    let items = flatten(
+      map(item => {
         return filter(
-          compose(allPass([startsWith(`${item.anchor.replace(/.[^.]+$/, "")}.`), endsWith(".kuvaus")]), prop("anchor")),
+          compose(
+            allPass([
+              startsWith(`${item.anchor.replace(/.[^.]+$/, "")}.`),
+              endsWith(".kuvaus")
+            ]),
+            prop("anchor")
+          ),
           stateObjectsSection4
-        )
-      }, filter(
-      compose(propEq("isChecked", true), prop("properties")),
-      stateObjectsSection4
-      ))
+        );
+      }, filter(compose(propEq("isChecked", true), prop("properties")), stateObjectsSection4))
     );
-    setCheckboxStatesSection4(items)
+    setCheckboxStatesSection4(items);
   }, [stateObjectsSection4]);
 
   return (

--- a/src/scenes/Koulutusmuodot/Lukiokoulutus/lupanakymat/LupanakymaA.js
+++ b/src/scenes/Koulutusmuodot/Lukiokoulutus/lupanakymat/LupanakymaA.js
@@ -271,7 +271,7 @@ const LupanakymaA = React.memo(
                     code="5"
                     isPreviewModeOn={isPreviewModeOn}
                     maaraykset={filterByTunniste(
-                      "valtakunnallinenKehittamistehtava",
+                      "erityinenkoulutustehtava",
                       maaraykset
                     )}
                     rajoitteet={valtakunnallisetKehittamistehtavatRajoitteet}

--- a/src/services/lomakkeet/dynamic.js
+++ b/src/services/lomakkeet/dynamic.js
@@ -404,7 +404,7 @@ export const createDynamicTextBoxBeChangeObjects = (
   }, kuvausChangeObjects);
 };
 
-export const createDynamicTextBoxBeCheckboxChangeObjects = (
+export const createBECheckboxChangeObjectsForDynamicTextBoxes = (
   checkboxChangeObj,
   koodi,
   rajoitteetByRajoiteIdAndKoodiarvo,

--- a/src/services/lomakkeet/dynamic.js
+++ b/src/services/lomakkeet/dynamic.js
@@ -17,11 +17,20 @@ import {
   startsWith,
   length,
   not,
-  toUpper
+  toUpper,
+  concat,
+  take,
+  values,
+  head,
+  split,
+  mapObjIndexed,
+  drop,
+  isEmpty
 } from "ramda";
 import { getAnchorPart } from "utils/common";
 import { getChangeObjByAnchor } from "components/02-organisms/CategorizedListRoot/utils";
 import { __ } from "i18n-for-browser";
+import { createAlimaarayksetBEObjects } from "../../helpers/rajoitteetHelper";
 
 export const createDynamicTextFields = (
   sectionId,
@@ -59,7 +68,7 @@ export const createDynamicTextFields = (
   ]);
 
   const seuraavaAnkkuri =
-    parseInt(apply(Math.max, nykyisetAnkkuriarvot), 10) + 1 || 0;
+    parseInt(apply(Math.max, nykyisetAnkkuriarvot), 10) + 1 || "0";
 
   const unremovedInLupaTextBoxes = sortBy(
     path(["meta", "ankkuri"]),
@@ -118,6 +127,11 @@ export const createDynamicTextFields = (
           );
           return (
             equals(changeObjAnkkuri, anchor) &&
+            pathEq(
+              ["properties", "metadata", "koodiarvo"],
+              maarays.koodiarvo,
+              changeObj
+            ) &&
             pathEq(["properties", "isDeleted"], true, changeObj)
           );
         }, changeObjects);
@@ -133,6 +147,11 @@ export const createDynamicTextFields = (
               previousInLupaTextBox
             )}.kuvaus`
           : `${sectionId}.${koodiarvo}.lisaaPainike.A`;
+
+        const kuvaus = path(
+          ["metadata", locale ? toUpper(locale) : "FI", "kuvaus"],
+          find(koodi => koodi.koodiarvo === koodiarvo, koodit || [])
+        );
 
         return isRemoved
           ? null
@@ -150,13 +169,14 @@ export const createDynamicTextFields = (
                     },
                     isPreviewModeOn,
                     isReadOnly: isPreviewModeOn || isReadOnly,
-                    isRemovable: maxAmountOfTextBoxes > 1,
-                    isRemoveBtnDisabled: numberOfTextBoxes === 1,
+                    isRemovable:
+                      maxAmountOfTextBoxes > 1 && numberOfTextBoxes > 1,
                     placeholder: __("common.kuvausPlaceholder"),
                     title: __("common.kuvaus"),
                     value:
                       path(["meta", "arvo"], maarays) ||
-                      path(["meta", "kuvaus"], maarays)
+                      path(["meta", "kuvaus"], maarays) ||
+                      kuvaus
                   }
                 }
               ]
@@ -276,4 +296,178 @@ export const createDynamicTextFields = (
       }
     ].filter(Boolean)
   );
+};
+
+export const createDynamicTextBoxBeChangeObjects = (
+  kuvausChangeObjects,
+  liittyvatMaaraykset,
+  kuvausKoodistosta,
+  isCheckboxChecked,
+  koodi,
+  maaraystyyppi,
+  maaraystyypit,
+  rajoitteetByRajoiteIdAndKoodiarvo,
+  checkboxChangeObj,
+  kohde,
+  kohteet
+) => {
+  return map(changeObj => {
+    const ankkuri = path(["properties", "metadata", "ankkuri"], changeObj);
+
+    const liittyvaMaarays = find(
+      maarays =>
+        maarays.koodiarvo === getAnchorPart(changeObj.anchor, 1) &&
+        pathEq(["meta", "ankkuri"], ankkuri, maarays),
+      liittyvatMaaraykset
+    );
+
+    /** Jos kuvaus on identtinen koodistosta tulevan kanssa ei tallenneta sitä lainkaan muutokselle.
+     *  Tällöin muutokset koodistoon näkyvät html-luvalla */
+    const kuvaus =
+      path(["properties", "value"], changeObj) === kuvausKoodistosta
+        ? null
+        : path(["properties", "value"], changeObj);
+    const isDeleted = path(["properties", "isDeleted"], changeObj);
+    const isMuokattu = liittyvaMaarays && !isDeleted;
+    const changeObjectDeleted = isDeleted && !liittyvaMaarays;
+    const tila = isCheckboxChecked && !isDeleted ? "LISAYS" : "POISTO";
+
+    const kuvausBEChangeObject = changeObjectDeleted
+      ? null
+      : Object.assign(
+          {},
+          {
+            generatedId: changeObj.anchor,
+            kohde,
+            koodiarvo: koodi.koodiarvo,
+            koodisto: koodi.koodisto.koodistoUri,
+            ...(kuvaus && { kuvaus }),
+            maaraystyyppi,
+            meta: {
+              ankkuri,
+              ...(kuvaus && { kuvaus }),
+              changeObjects: flatten(
+                concat(take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)), [
+                  checkboxChangeObj,
+                  changeObj
+                ])
+              ).filter(Boolean)
+            },
+            tila,
+            maaraysUuid: tila === "POISTO" ? liittyvaMaarays.uuid : null
+          }
+        );
+
+    /** Jos tekstikenttämääräystä on muokattu, pitää luoda poisto-objekti määräykselle */
+    const muokkausPoistoObjekti = isMuokattu
+      ? {
+          kohde,
+          koodiarvo: koodi.koodiarvo,
+          koodisto: koodi.koodisto.koodistoUri,
+          tila: "POISTO",
+          maaraysUuid: liittyvaMaarays.uuid,
+          maaraystyyppi
+        }
+      : null;
+
+    let alimaaraykset = [];
+
+    const kohteenTarkentimenArvo = path(
+      [1, "properties", "value", "value"],
+      head(values(rajoitteetByRajoiteIdAndKoodiarvo))
+    );
+
+    const rajoitevalinnanAnkkuriosa = kohteenTarkentimenArvo
+      ? nth(1, split("-", kohteenTarkentimenArvo))
+      : null;
+
+    if (
+      kohteenTarkentimenArvo &&
+      (rajoitevalinnanAnkkuriosa === ankkuri || !rajoitevalinnanAnkkuriosa)
+    ) {
+      // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
+      // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
+      // loput toisiinsa "alenevassa polvessa".
+      alimaaraykset = values(
+        mapObjIndexed(asetukset => {
+          return createAlimaarayksetBEObjects(
+            kohteet,
+            maaraystyypit,
+            kuvausBEChangeObject,
+            drop(2, asetukset)
+          );
+        }, rajoitteetByRajoiteIdAndKoodiarvo)
+      );
+    }
+
+    return [kuvausBEChangeObject, muokkausPoistoObjekti, alimaaraykset];
+  }, kuvausChangeObjects);
+};
+
+export const createDynamicTextBoxBeCheckboxChangeObjects = (
+  checkboxChangeObj,
+  koodi,
+  rajoitteetByRajoiteIdAndKoodiarvo,
+  kohteet,
+  kohde,
+  maaraystyypit,
+  maaraystyyppi,
+  liittyvatMaaraykset,
+  isCheckboxChecked,
+  locale,
+  nimi
+) => {
+  let checkboxBEchangeObject = null;
+  checkboxBEchangeObject = checkboxChangeObj
+    ? {
+        generatedId: `${nimi}-${Math.random()}`,
+        kohde,
+        koodiarvo: koodi.koodiarvo,
+        koodisto: koodi.koodisto.koodistoUri,
+        kuvaus: koodi.metadata[locale].kuvaus,
+        maaraystyyppi,
+        meta: {
+          changeObjects: flatten(
+            concat(take(2, values(rajoitteetByRajoiteIdAndKoodiarvo)), [
+              checkboxChangeObj
+            ])
+          ).filter(Boolean)
+        },
+        tila: checkboxChangeObj.properties.isChecked ? "LISAYS" : "POISTO"
+      }
+    : null;
+
+  // Muodostetaan tehdyistä rajoittuksista objektit backendiä varten.
+  // Linkitetään ensimmäinen rajoitteen osa yllä luotuun muutokseen ja
+  // loput toisiinsa "alenevassa polvessa".
+  const alimaaraykset =
+    checkboxBEchangeObject && !isEmpty(rajoitteetByRajoiteIdAndKoodiarvo)
+      ? values(
+          mapObjIndexed(asetukset => {
+            return createAlimaarayksetBEObjects(
+              kohteet,
+              maaraystyypit,
+              checkboxBEchangeObject,
+              drop(2, asetukset)
+            );
+          }, rajoitteetByRajoiteIdAndKoodiarvo)
+        )
+      : null;
+
+  /** Jos checkboxi ei ole checkattu. Luodaan poisto-objektit koulutustehtävään
+   * liittyville määräyksille (eli tekstikentille) */
+  const uncheckedCheckBoxPoistot = !isCheckboxChecked
+    ? map(maarays => {
+        return {
+          kohde,
+          koodiarvo: koodi.koodiarvo,
+          koodisto: koodi.koodisto.koodistoUri,
+          tila: "POISTO",
+          maaraysUuid: maarays.uuid,
+          maaraystyyppi
+        };
+      }, liittyvatMaaraykset)
+    : null;
+
+  return [checkboxBEchangeObject, uncheckedCheckBoxPoistot, alimaaraykset];
 };

--- a/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/5-erityisetKoulutustehtavat.js
@@ -1,5 +1,5 @@
 import { isAdded, isInLupa, isRemoved } from "css/label";
-import { filter, find, flatten, hasPath, map, pathEq, propEq } from "ramda";
+import { filter, find, flatten, map, pathEq, propEq } from "ramda";
 import { getPOErityisetKoulutustehtavatFromStorage } from "helpers/poErityisetKoulutustehtavat";
 import { getLisatiedotFromStorage } from "helpers/lisatiedot";
 import { getLocalizedProperty } from "../utils";
@@ -33,16 +33,12 @@ export async function erityisetKoulutustehtavat(
             propEq("koodisto", "poerityinenkoulutustehtava", m),
           maaraykset
         );
-        const kuvausmaaraykset = filter(
-          hasPath(["meta", "kuvaus"]),
-          tehtavaanLiittyvatMaaraykset
-        );
 
         return {
           anchor: erityinenKoulutustehtava.koodiarvo,
           categories: createDynamicTextFields(
             sectionId,
-            kuvausmaaraykset,
+            tehtavaanLiittyvatMaaraykset,
             changeObjects,
             erityinenKoulutustehtava.koodiarvo,
             onAddButtonClick,

--- a/src/services/lomakkeet/esi-ja-perusopetus/7-muutEhdot.js
+++ b/src/services/lomakkeet/esi-ja-perusopetus/7-muutEhdot.js
@@ -1,6 +1,6 @@
 import { isAdded, isInLupa, isRemoved } from "css/label";
 import { __ } from "i18n-for-browser";
-import { filter, find, flatten, hasPath, map, pathEq, propEq } from "ramda";
+import { filter, find, flatten, map, pathEq, propEq } from "ramda";
 import { getPOMuutEhdotFromStorage } from "helpers/poMuutEhdot";
 import { getLisatiedotFromStorage } from "helpers/lisatiedot";
 import { getLocalizedProperty } from "../utils";
@@ -36,10 +36,6 @@ export async function muutEhdot(
           ),
         maaraykset
       );
-      const kuvausmaaraykset = filter(
-        hasPath(["meta", "kuvaus"]),
-        ehtoonLiittyvatMaaraykset
-      );
 
       return {
         anchor: ehto.koodiarvo,
@@ -66,7 +62,7 @@ export async function muutEhdot(
         ],
         categories: createDynamicTextFields(
           sectionId,
-          kuvausmaaraykset,
+          ehtoonLiittyvatMaaraykset,
           changeObjects,
           ehto.koodiarvo,
           onAddButtonClick,

--- a/src/services/lomakkeet/lukiokoulutus/4-erityisetKoulutustehtavat.js
+++ b/src/services/lomakkeet/lukiokoulutus/4-erityisetKoulutustehtavat.js
@@ -1,5 +1,5 @@
 import { isAdded, isInLupa, isRemoved } from "css/label";
-import { filter, find, flatten, hasPath, map, pathEq, propEq } from "ramda";
+import { filter, find, flatten, map, pathEq, propEq } from "ramda";
 import { getLisatiedotFromStorage } from "helpers/lisatiedot";
 import { getLocalizedProperty } from "../utils";
 import localforage from "localforage";
@@ -35,16 +35,12 @@ export async function getErityisetKoulutustehtavatLukio(
             propEq("koodisto", "lukioerityinenkoulutustehtavauusi", m),
           maaraykset
         );
-        const kuvausmaaraykset = filter(
-          hasPath(["meta", "kuvaus"]),
-          tehtavaanLiittyvatMaaraykset
-        );
 
         return {
           anchor: erityinenKoulutustehtava.koodiarvo,
           categories: createDynamicTextFields(
             sectionId,
-            kuvausmaaraykset,
+            tehtavaanLiittyvatMaaraykset,
             changeObjects,
             erityinenKoulutustehtava.koodiarvo,
             onAddButtonClick,

--- a/src/services/lomakkeet/lukiokoulutus/5-valtakunnallinenKehittamistehtava.js
+++ b/src/services/lomakkeet/lukiokoulutus/5-valtakunnallinenKehittamistehtava.js
@@ -14,7 +14,6 @@ export async function getValtakunnallinenKehittamistehtavalomake(
     pathEq(["koodisto", "koodistoUri"], "lisatietoja"),
     lisatiedot || []
   );
-
   const lisatietomaarays = find(propEq("koodisto", "lisatietoja"), maaraykset);
   let kehittamistehtavatStructure = [
     {
@@ -33,10 +32,27 @@ export async function getValtakunnallinenKehittamistehtavalomake(
     }
   ];
   if (checkboxStatesSection4.length > 0) {
-    kehittamistehtavatStructure = flatten(concat(kehittamistehtavatStructure,
-      [
+    kehittamistehtavatStructure = flatten(
+      concat(kehittamistehtavatStructure, [
         map(checkboxObjSection4 => {
-          const anchor = `${getAnchorPart(checkboxObjSection4.anchor, 1)}.${getAnchorPart(checkboxObjSection4.anchor, 2)}`;
+          const anchor = `${getAnchorPart(
+            checkboxObjSection4.anchor,
+            1
+          )}.${getAnchorPart(checkboxObjSection4.anchor, 2)}`;
+          const kuvausNro = getAnchorPart(checkboxObjSection4.anchor, 2);
+
+          const hasMaarays = !!find(
+            maarays =>
+              path(["meta", "isValtakunnallinenKehitystehtava"], maarays) &&
+              path(["meta", "ankkuri"], maarays) === kuvausNro &&
+              pathEq(
+                ["properties", "forChangeObject", "koodiarvo"],
+                maarays.koodiarvo,
+                checkboxObjSection4
+              ),
+            maaraykset
+          );
+
           return {
             anchor,
             components: [
@@ -44,7 +60,7 @@ export async function getValtakunnallinenKehittamistehtavalomake(
                 anchor: "valintaelementti",
                 name: "CheckboxWithLabel",
                 properties: {
-                  isChecked: path(["properties", "metadata", "isChecked"], checkboxObjSection4),
+                  isChecked: hasMaarays,
                   isIndeterminate: false,
                   isPreviewModeOn,
                   isReadOnly: _isReadOnly,
@@ -58,39 +74,43 @@ export async function getValtakunnallinenKehittamistehtavalomake(
             ]
           };
         }, checkboxStatesSection4)
-      ]));
+      ])
+    );
   } else {
-    kehittamistehtavatStructure = flatten(concat(kehittamistehtavatStructure, [{
-      anchor: "info",
+    kehittamistehtavatStructure = flatten(
+      concat(kehittamistehtavatStructure, [
+        {
+          anchor: "info",
+          components: [
+            {
+              anchor: "valinta",
+              name: "StatusTextRow",
+              properties: {
+                title: __("education.valtakunnallinenKehittamistehtavaInfo2")
+              }
+            }
+          ]
+        }
+      ])
+    );
+  }
+  let lisatiedotStructure = flatten([
+    {
+      anchor: "valtakunnalliset-kehittamistehtavat",
+      layout: { margins: { top: "large" } },
       components: [
         {
-          anchor: "valinta",
+          anchor: "lisatiedot-info",
           name: "StatusTextRow",
+          styleClasses: ["pt-8", "border-t"],
           properties: {
-            title: __("education.valtakunnallinenKehittamistehtavaInfo2")
+            title: __("common.lisatiedotInfo")
           }
         }
       ]
-    }]));
-  }
-  let lisatiedotStructure = flatten(
-    [
-      {
-        anchor: "valtakunnalliset-kehittamistehtavat",
-        layout: { margins: { top: "large" } },
-        components: [
-          {
-            anchor: "lisatiedot-info",
-            name: "StatusTextRow",
-            styleClasses: ["pt-8", "border-t"],
-            properties: {
-              title: __("common.lisatiedotInfo")
-            }
-          }
-        ]
-      },
-      lisatiedotObj
-        ? {
+    },
+    lisatiedotObj
+      ? {
           anchor: "lisatiedot",
           components: [
             {
@@ -111,9 +131,10 @@ export async function getValtakunnallinenKehittamistehtavalomake(
             }
           ]
         }
-        : null
-    ]
-  );
+      : null
+  ]);
 
-  return flatten([kehittamistehtavatStructure, lisatiedotStructure]).filter(Boolean);
+  return flatten([kehittamistehtavatStructure, lisatiedotStructure]).filter(
+    Boolean
+  );
 }

--- a/src/services/lomakkeet/lukiokoulutus/7-muutEhdot.js
+++ b/src/services/lomakkeet/lukiokoulutus/7-muutEhdot.js
@@ -1,5 +1,5 @@
 import { isAdded, isInLupa, isRemoved } from "css/label";
-import { filter, find, flatten, hasPath, map, pathEq, propEq } from "ramda";
+import { filter, find, flatten, map, pathEq, propEq } from "ramda";
 import { getLisatiedotFromStorage } from "helpers/lisatiedot";
 import { getLocalizedProperty } from "../utils";
 import localforage from "localforage";
@@ -38,10 +38,6 @@ export async function muutEhdot(
           ),
         maaraykset
       );
-      const kuvausmaaraykset = filter(
-        hasPath(["meta", "kuvaus"]),
-        ehtoonLiittyvatMaaraykset
-      );
 
       return {
         anchor: ehto.koodiarvo,
@@ -68,7 +64,7 @@ export async function muutEhdot(
         ],
         categories: createDynamicTextFields(
           sectionId,
-          kuvausmaaraykset,
+          ehtoonLiittyvatMaaraykset,
           changeObjects,
           ehto.koodiarvo,
           onAddButtonClick,


### PR DESCRIPTION
- Sisältää sekä CSCOIVA-1994 että CSCOIVA-1905 koodit (määräysten huomioon ottaminen osiossa 5)
- Luodaan tarvittavat muutos-objektit, kun määräyksiä lisätään/poistetaan/muokataan
- Ei tallenneta kuvausta lainkaan, jos tekstikentän sisältö sama kuin koodistosta saatu arvo.
- Lukion osio 4 ei käytä samoja funktioita kuin muut kolme dynaamisia tekstikenttiä sisältävää osiota, koska siihen liittyy valtakunnalliset kehittämistehtävät
