### PR TITLE
CSCOIVA-2002: Dialogin korjaukset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="fi">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/02-organisms/ConfirmDialog/index.js
+++ b/src/components/02-organisms/ConfirmDialog/index.js
@@ -1,12 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DialogContent from "@material-ui/core/DialogContent";
-import DialogActions from "@material-ui/core/DialogActions";
+import MuiDialogActions from "@material-ui/core/DialogActions";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
-import DialogTitle from "../DialogTitle";
+import DialogTitle from "../DialogTitle/index";
 import "../../../css/tailwind.css";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import { withStyles } from "@material-ui/core/styles";
+
+const DialogActions = withStyles(theme => ({
+  root: {
+    margin: 0,
+    paddingLeft: theme.spacing(4),
+    paddingRight: theme.spacing(4),
+    paddingBottom: theme.spacing(4)
+  }
+}))(MuiDialogActions);
 
 const ConfirmDialog = props => {
   const {
@@ -25,30 +35,32 @@ const ConfirmDialog = props => {
       fullWidth={true}
       aria-labelledby="confirm-dialog"
       maxWidth="sm"
+      className="min-w-64"
     >
       <DialogTitle id="confirm-dialog" onClose={onClose}>
-        {messages.title}
+        <span className="mr-12">{messages.title}</span>
       </DialogTitle>
       <DialogContent>
         <div className="py-2 px-8">{messages.content}</div>
       </DialogContent>
       <DialogActions>
-        <div className="flex pr-6 pb-4">
-          <div className="mr-4">
-            <Button onClick={handleCancel} color="primary" variant="outlined">
-              {messages.cancel}
-            </Button>
-          </div>
+        <div className="flex flex-col sm:flex-row flex-grow sm:flex-grow-0">
+          <Button
+            onClick={handleCancel}
+            color="primary"
+            variant="outlined"
+            className="mb-4" // sm:mr-4 ei toimi, koska se ylikirjoittuu
+          >
+            {messages.cancel}
+          </Button>
           {!!handleExitAndAbandonChanges && (
-            <div className="mr-4">
-              <Button
-                onClick={handleExitAndAbandonChanges}
-                color="primary"
-                variant="outlined"
-              >
-                {messages.noSave}
-              </Button>
-            </div>
+            <Button
+              onClick={handleExitAndAbandonChanges}
+              color="primary"
+              variant="outlined"
+            >
+              {messages.noSave}
+            </Button>
           )}
           <Button
             onClick={handleOk}

--- a/src/components/02-organisms/ConfirmDialog/index.js
+++ b/src/components/02-organisms/ConfirmDialog/index.js
@@ -20,7 +20,7 @@ const DialogActions = withStyles(theme => ({
 }))(MuiDialogActions);
 
 const useStyles = makeStyles(theme => ({
-  paper: { minWidth: "400px" },
+  paper: { minWidth: "360px" },
   root: {
     minWidth: "300px",
     "& > *:not(:last-child)": {

--- a/src/components/02-organisms/ConfirmDialog/index.js
+++ b/src/components/02-organisms/ConfirmDialog/index.js
@@ -8,6 +8,7 @@ import DialogTitle from "../DialogTitle/index";
 import "../../../css/tailwind.css";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { withStyles } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 
 const DialogActions = withStyles(theme => ({
   root: {
@@ -17,6 +18,20 @@ const DialogActions = withStyles(theme => ({
     paddingBottom: theme.spacing(4)
   }
 }))(MuiDialogActions);
+
+const useStyles = makeStyles(theme => ({
+  paper: { minWidth: "400px" },
+  root: {
+    minWidth: "300px",
+    "& > *:not(:last-child)": {
+      marginBottom: "20px",
+      [theme.breakpoints.up("sm")]: {
+        marginRight: theme.spacing(1),
+        marginBottom: theme.spacing(0)
+      }
+    }
+  }
+}));
 
 const ConfirmDialog = props => {
   const {
@@ -29,13 +44,15 @@ const ConfirmDialog = props => {
     loadingSpinner = false
   } = props;
 
+  const classes = useStyles();
+
   return (
     <Dialog
       open={isConfirmDialogVisible}
       fullWidth={true}
       aria-labelledby="confirm-dialog"
       maxWidth="sm"
-      className="min-w-64"
+      classes={{ paper: classes.paper }}
     >
       <DialogTitle id="confirm-dialog" onClose={onClose}>
         <span className="mr-12">{messages.title}</span>
@@ -44,13 +61,12 @@ const ConfirmDialog = props => {
         <div className="py-2 px-8">{messages.content}</div>
       </DialogContent>
       <DialogActions>
-        <div className="flex flex-col sm:flex-row flex-grow sm:flex-grow-0">
-          <Button
-            onClick={handleCancel}
-            color="primary"
-            variant="outlined"
-            className="mb-4" // sm:mr-4 ei toimi, koska se ylikirjoittuu
-          >
+        <div
+          className={
+            classes.root + " flex flex-col sm:flex-row flex-grow sm:flex-grow-0"
+          }
+        >
+          <Button onClick={handleCancel} color="primary" variant="outlined">
             {messages.cancel}
           </Button>
           {!!handleExitAndAbandonChanges && (

--- a/src/components/02-organisms/DialogTitle/index.js
+++ b/src/components/02-organisms/DialogTitle/index.js
@@ -1,4 +1,4 @@
-import {withStyles} from "@material-ui/core";
+import { withStyles } from "@material-ui/core";
 import MuiDialogTitle from "@material-ui/core/DialogTitle/DialogTitle";
 import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
@@ -10,7 +10,7 @@ const DialogTitle = withStyles(theme => ({
   root: {
     margin: 0,
     paddingLeft: theme.spacing(4),
-    paddingTop: theme.spacing(3),
+    paddingTop: theme.spacing(4),
     paddingBottom: 0,
     background: "#ffffff"
   },
@@ -42,8 +42,7 @@ DialogTitle.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
-  ]),
+  ])
 };
-
 
 export default DialogTitle;

--- a/src/components/03-templates/AvoimetAsiat/index.js
+++ b/src/components/03-templates/AvoimetAsiat/index.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Table from "../../02-organisms/Table";
-import ConfirmDialog from "../../02-organisms/ConfirmDialog";
+import ConfirmDialog from "../../02-organisms/ConfirmDialog/index";
 import { generateAvoimetAsiatTableStructure } from "../../../utils/asiatUtils";
 import { useIntl } from "react-intl";
 import { useLocation, useHistory } from "react-router-dom";

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,19 @@ localforage.config({
   name: "Oiva App"
 });
 
-const theme = createMuiTheme();
+const theme = createMuiTheme({
+  breakpoints: {
+    values: {
+      sm: 576,
+      md: 768,
+      lg: 992,
+      xl: 1200,
+      xxl: 1600,
+      kk: 2160, // 2k
+      kkk: 3240 // 3k
+    }
+  }
+});
 
 theme.typography.useNextVariants = true;
 

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -18,4 +18,4 @@ export const ROLE_NIMENKIRJOITTAJA = "OIVA_APP_NIMENKIRJOITTAJA";
 export const ROLE_KATSELIJA = "OIVA_APP_KATSELIJA";
 
 // SESSION
-export const sessionTimeoutInMinutes = 20;
+export const sessionTimeoutInMinutes = 0.3;

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -18,4 +18,4 @@ export const ROLE_NIMENKIRJOITTAJA = "OIVA_APP_NIMENKIRJOITTAJA";
 export const ROLE_KATSELIJA = "OIVA_APP_KATSELIJA";
 
 // SESSION
-export const sessionTimeoutInMinutes = 0.3;
+export const sessionTimeoutInMinutes = 20;

--- a/src/utils/asiatUtils.js
+++ b/src/utils/asiatUtils.js
@@ -5,7 +5,6 @@ import ProcedureHandler from "../components/02-organisms/procedureHandler";
 import { resolveLocalizedOrganizationName } from "../modules/helpers";
 import { localizeRouteKey } from "utils/common";
 import { AppRoute } from "const/index";
-import languages from "i18n/definitions/languages";
 
 const asiatTableColumnSetup = avoimet => {
   return [


### PR DESCRIPTION
* ConfirmDialog-komponentin tyylit muokattu toivotunlaisiksi (esim. Merkitse päätetyksi -dialogi).
* Material-UI:n breakpointit asetettu arvoiltaan samoiksi, kuin TailwindCSS:n breakpointit.
* Huom! Muut kuin ConfirmDialog:ia pohjanaan käyttävät dialogit eivät korjaannu tämän PR:n koodeilla.
